### PR TITLE
Transfer fix pablo

### DIFF
--- a/contracts/SecurityTokenRegistrar.sol
+++ b/contracts/SecurityTokenRegistrar.sol
@@ -15,6 +15,9 @@ contract SecurityTokenRegistrar {
       bytes32 securityDetails;
     }
 
+    //Shoud be set to false when we have more TransferManager options
+    bool addGeneralTransferManager = true;
+
     mapping(address => SecurityTokenData) public securityTokens;
     mapping(string => address) symbols;
 
@@ -43,14 +46,17 @@ contract SecurityTokenRegistrar {
         require(bytes(_name).length > 0 && bytes(_symbol).length > 0);
         ITickerRegistrar(tickerRegistrar).checkValidity(_symbol, _owner);
         address newSecurityTokenAddress = new SecurityToken(
-          _owner,
           _name,
           _symbol,
           _decimals,
           _securityDetails,
-          moduleRegistry,
-          transferManagerFactory
-          );
+          moduleRegistry
+        );
+        if (addGeneralTransferManager) {
+          uint256[] memory perm;
+          SecurityToken(newSecurityTokenAddress).addModule(transferManagerFactory, "", 0, perm, true);
+        }
+        SecurityToken(newSecurityTokenAddress).transferOwnership(_owner);
         securityTokens[newSecurityTokenAddress] = SecurityTokenData(_symbol, _owner, _securityDetails);
         symbols[_symbol] = newSecurityTokenAddress;
         LogNewSecurityToken(_symbol, newSecurityTokenAddress, _owner);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -55,7 +55,7 @@ module.exports = async (deployer, network, accounts) => {
 
   // 2. Deploy Token
   let STRegistrar = await SecurityTokenRegistrar.deployed();
-  let r_generateSecurityToken = await STRegistrar.generateSecurityToken(owner, name, symbol, 18, securityDetails);
+  let r_generateSecurityToken = await STRegistrar.generateSecurityToken(owner, name, symbol, 18, securityDetails, {from: owner});
   let newSecurityTokenAddress = r_generateSecurityToken.logs[0].args._securityTokenAddress;
   let securityToken = await SecurityToken.at(newSecurityTokenAddress);
   //console.log(securityToken);


### PR DESCRIPTION

@adamdossa please review:

1- Added logic on verifyTransfer to bypass _from check if _from is address(0). A better solution would be for the TransferManager to get a reference to the STO and check that _from is the STO instead, but with the current architecture, I couldn't figure out how to get it.

2- I believe that the verifications should be:

`return ((whitelist[_from].fromTime <= now) && (whitelist[_to].toTime <= now));`

as opposed to 

`return ((whitelist[_from].fromTime >= now) && (whitelist[_to].toTime >= now));`

We'll be receiving the date when the lockup ENDS. So transfers should return true when we are past the fromTime/toTime.

We'll have 0x123, June 2018, June 2018.
If I try to do a transfer on March 2018 (June 2018 <= March 2018 is false), the transfer will fail because we are on lockup until June.

Whereas in the code we had before, the transfers would be allowed UNTIL the date entered.
