### PR TITLE
Simple Daico

### DIFF
--- a/contracts/modules/Fund/ISimpleDaicoFund.sol
+++ b/contracts/modules/Fund/ISimpleDaicoFund.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.23;
+
+contract ISimpleDaicoFund {
+  function callOnTransfer(address _sender, address _receiver, uint256 _amount) public returns (bool);
+}

--- a/contracts/modules/Fund/SimpleDaicoFund.sol
+++ b/contracts/modules/Fund/SimpleDaicoFund.sol
@@ -1,0 +1,179 @@
+pragma solidity ^0.4.23;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../../interfaces/IST20.sol";
+import "../Governance/VoteGovernance.sol";
+
+contract SimpleDaicoFund {
+    using SafeMath for uint256;
+
+////////////////////
+// Configurations //
+////////////////////
+
+    constructor (address _securityToken, address _polyAddress) public
+    IModule(_securityToken, _polyAddress)
+    {
+    }
+
+    function configure(
+        uint256 _tap,
+        uint256 _votingPeriod,
+        address _tapRecipient,
+        address _owner,
+        address _tokenContract
+    ) public onlyFactory {
+        tap = _tap;
+        votingPeriod = _votingPeriod;
+        tapRecipient = _tapRecipient;
+        owner = _owner;
+        tokenContract = IST20(_tokenContract);
+    }
+
+    function getInitFunction() public returns(bytes4) {
+        return bytes4(keccak256("configure(uint256,uint256,address,address,address)"));
+    }
+
+    function getPermissions() public view returns(bytes32[]) {
+        bytes32[] memory allPermissions = new bytes32[](0);
+        return allPermissions;
+    }
+
+/////////////
+// General //
+/////////////
+
+    function() public payable {}
+
+    address public owner;
+    address public transferManager;
+    IST20 public tokenContract;
+
+    function getETHBalance() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function setTransferManager(address _transferManager) public {
+        require(msg.sender == owner);
+        require(transferManager == address(0));
+        transferManager = _transferManager;
+    }
+
+/////////////////////////////////////////////
+// This section contains logic for the tap //
+/////////////////////////////////////////////
+
+    uint256 public tap; // wei per second
+    uint256 public lastWithdrawTime = now;
+    address public tapRecipient;
+
+    function getAccumulatedTap() public view returns(uint256) {
+        uint256 amountWei = uint256(tap.mul(now.sub(lastWithdrawTime)));
+        if(address(this).balance < amountWei) {
+            amountWei = address(this).balance;
+        }
+            return amountWei;
+    }
+
+    function claimAccumulatedTap() public notRefund {
+        require(msg.sender == owner);
+        require(_payout());
+    }
+
+    function changeTapRecipient(address _newTapRecipient) public notRefund {
+        require(msg.sender == owner);
+        tapRecipient = _newTapRecipient;
+    }
+
+    function _payout() private notRefund returns (bool){
+        uint256 amountWei = getAccumulatedTap();
+        lastWithdrawTime = now;
+        tapRecipient.transfer(amountWei);
+        return true;
+    }
+
+///////////////////////////////////////////////////
+// This section contains logic for token refunds //
+///////////////////////////////////////////////////
+
+    bool public activeRefund = false;
+
+    modifier notRefund() {
+        require(!activeRefund);
+        _;
+    }
+
+  // Requires token holder to first approve this contract for full token balance transfer
+    function refundTokens() public {
+        uint256 tokenHolderBalance = tokenContract.balanceOf(msg.sender);
+        require(tokenHolderBalance > 0);
+        require(activeRefund);
+        uint256 refundValue = (tokenHolderBalance.mul(address(this).balance)).div(tokenContract.totalSupply());
+        require(refundValue > 0);
+        tokenContract.burnFrom(msg.sender,tokenHolderBalance); // Need to validate this implementation in ST 20 or TokenBurner
+        msg.sender.transfer(refundValue);
+    }
+
+////////////////////////////////////////////////
+// This section contains logic for governance //
+////////////////////////////////////////////////
+
+    Vote public voteContract;
+
+    bool public activeTapVote = false;
+    bool public activeRefundVote = false;
+    uint256 public votingPeriod;
+    uint256 public proposedTapIncrease;
+
+    function activeVote() public view returns (bool) {
+        if (activeTapVote || activeRefundVote) {
+            return true;
+        }
+        return false;
+    }
+
+    function startTapVote(uint256 _proposedIncrease) public notRefund {
+        require(msg.sender == owner);
+        require(!activeVote());
+        activeTapVote = true;
+        proposedTapIncrease = _proposedIncrease;
+        voteContract = new Vote(now.add(votingPeriod), address(this), address(tokenContract));
+    }
+
+    function startRefundVote() public notRefund {
+        require(tokenContract.balanceOf(msg.sender) > 0);
+        require(!activeVote());
+        activeRefundVote = true;
+        voteContract = new Vote(now.add(votingPeriod), address(this), address(tokenContract));
+    }
+
+    function finalizeTapVote() public notRefund {
+        require(activeTapVote);
+        bool result = voteContract.finalResult();
+        if (result) {
+            require(_payout());
+            tap = tap.add(proposedTapIncrease);
+        }
+        activeTapVote = false;
+        proposedTapIncrease = 0;
+        delete voteContract;
+    }
+
+    function finalizeRefundVote() public notRefund {
+        require(activeRefundVote);
+        bool result = voteContract.finalResult();
+        if (result) {
+            activeRefund = true;
+        }
+        activeRefundVote = false;
+        delete voteContract;
+    }
+
+    function callOnTransfer(address _sender, address _receiver, uint256 _amount) public returns (bool) {
+        require(msg.sender == address(transferManager));
+        if (activeVote()) {
+            require(voteContract.callOnTransfer(_sender,_receiver,_amount));
+        }
+        return true;
+    }
+}

--- a/contracts/modules/Fund/SimpleDaicoFund.sol
+++ b/contracts/modules/Fund/SimpleDaicoFund.sol
@@ -4,7 +4,10 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../../interfaces/IST20.sol";
 import "../Governance/VoteGovernance.sol";
 
-contract SimpleDaicoFund {
+import "../../interfaces/IModule.sol";
+import "../../interfaces/ITokenBurner.sol";
+
+contract SimpleDaicoFund is IModule, ITokenBurner {
     using SafeMath for uint256;
 
 ////////////////////

--- a/contracts/modules/Fund/SimpleDaicoFundFactory.sol
+++ b/contracts/modules/Fund/SimpleDaicoFundFactory.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.4.21;
+
+import "./SimpleDaicoFund.sol";
+import "../../interfaces/IModuleFactory.sol";
+import "../../interfaces/IModule.sol";
+
+
+contract SimpleDaicoFundFactory is IModuleFactory {
+
+    constructor (address _polyAddress) public
+      IModuleFactory(_polyAddress)
+    {
+
+    }
+
+    function deploy(bytes _data) external returns(address) {
+        if(getCost() > 0)
+            require(polyToken.transferFrom(msg.sender, owner, getCost()), "Failed transferFrom because of sufficent Allowance is not provided");
+        //Check valid bytes - can only call module init function
+        SimpleDaicoFund daicoFund = new SimpleDaicoFund(msg.sender, address(polyToken));
+        //Checks that _data is valid (not calling anything it shouldn't)
+        require(getSig(_data) == daicoFund.getInitFunction(), "Provided data is not valid");
+        require(address(daicoFund).call(_data), "Un-successfull call");
+        return address(daicoFund);
+    }
+
+    function getCost() public view returns(uint256) {
+        return 0;
+    }
+
+    function getType() public view returns(uint8) {
+        return 5; // Is this okay?
+    }
+
+    function getName() public view returns(bytes32) {
+        return "SimpleDaicoFund";
+    }
+
+    function getDescription() public view returns(string) {
+        return "";
+    }
+
+    function getTitle() public view returns(string) {
+        return "Simple Daico Fund";
+    }
+
+    function getInstructions() public view returns(string) {
+        return "";
+    }
+
+    function getTags() public view returns(bytes32[]) {
+        bytes32[] memory availableTags = new bytes32[](1);
+        availableTags[0] = "ETH";
+        return availableTags;
+    }
+
+}

--- a/contracts/modules/Governance/VoteGovernance.sol
+++ b/contracts/modules/Governance/VoteGovernance.sol
@@ -1,0 +1,103 @@
+pragma solidity ^0.4.23;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../../interfaces/IST20.sol";
+
+contract Vote {
+
+  using SafeMath for uint256;
+
+  constructor(
+    uint256 _endTime,
+    address _daicoContract,
+    address _tokenContract
+  ) public {
+    endTime = _endTime;
+    daicoContract = _daicoContract;
+    tokenContract = IST20(_tokenContract);
+  }
+
+  IST20 public tokenContract;
+  address public daicoContract;
+
+  uint256 public endTime;
+  uint256 public cumulativeYes;
+  uint256 public cumulativeNo;
+
+  mapping(address => voteInstance) public voteByAddress;
+
+  struct voteInstance {
+    uint256 time;
+    uint256 weight;
+    bool vote;
+  }
+
+  function calcAbstain() public view returns (uint256) {
+    return (tokenContract.totalSupply().add(cumulativeNo)).sub(cumulativeYes);
+  }
+
+  function tallyResult() public view returns (bool) {
+    if (cumulativeYes > cumulativeNo.add(calcAbstain())) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  function finalResult() public view returns (bool) {
+    require(now > endTime);
+    return tallyResult();
+  }
+
+  function submitVote(bool _vote) public returns (bool) {
+    require(tokenContract.balanceOf(msg.sender) > 0);
+    require(endTime > now);
+    uint256 voteWeight = tokenContract.balanceOf(msg.sender);
+    require(voteByAddress[msg.sender].time == 0);
+    voteByAddress[msg.sender].time = now;
+    voteByAddress[msg.sender].weight = voteWeight;
+    voteByAddress[msg.sender].vote = _vote;
+    if (_vote == true) {
+      cumulativeYes = cumulativeYes.add(voteWeight);
+    }
+    if (_vote == false) {
+      cumulativeNo = cumulativeNo.add(voteWeight);
+    }
+    return true;
+  }
+
+  function callOnTransfer(address _sender, address _receiver, uint256 _amount) public returns (bool) {
+    require(msg.sender == address(daicoContract));
+    uint256 senderVote = voteByAddress[_sender].weight;
+    uint256 receiverVote = voteByAddress[_receiver].weight;
+    if (senderVote > 0) {
+      voteByAddress[_sender].weight = senderVote.sub(_amount);
+      _weightDecrease(_sender,_amount);
+      if (receiverVote > 0) {
+        voteByAddress[_receiver].weight = receiverVote.add(_amount);
+        _weightIncrease(_receiver,_amount);
+      }
+    }
+    return true;
+  }
+
+  function _weightDecrease(address _tokenholder, uint256 _amount) private {
+    bool vote = voteByAddress[_tokenholder].vote;
+    if (vote == true) {
+      cumulativeYes = cumulativeYes.sub(_amount);
+    }
+    if (vote == false) {
+      cumulativeNo = cumulativeNo.sub(_amount);
+    }
+  }
+
+  function _weightIncrease(address _tokenholder, uint256 _amount) private {
+    bool vote = voteByAddress[_tokenholder].vote;
+    if (vote == true) {
+      cumulativeYes = cumulativeYes.add(_amount);
+    }
+    if (vote == false) {
+      cumulativeNo = cumulativeNo.add(_amount);
+    }
+  }
+}

--- a/contracts/modules/TransferManager/SimpleDaicoTransferManager.sol
+++ b/contracts/modules/TransferManager/SimpleDaicoTransferManager.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.23;
+
+import "./ITransferManager.sol";
+import "../Fund/ISimpleDaicoFund.sol";
+
+/////////////////////
+// Module permissions
+/////////////////////
+
+contract SimpleDaicoTransferManager is ITransferManager {
+
+    ISimpleDaicoFund public daicoContract;
+
+    constructor (address _securityToken,address _polyAddress) public IModule(_securityToken, _polyAddress) {}
+
+    function verifyTransfer(address _from, address _to, uint256 _amount) public view returns(Result) {
+        if (!paused) {
+            return (daicoContract.callOnTransfer(_from,_to,_amount) ? Result.VALID : Result.NA);
+        }
+        return Result.NA;
+    }
+
+    function configure(address _daicoContract) public onlyFactory {
+        daicoContract = ISimpleDaicoFund(_daicoContract);
+    }
+
+    function getInitFunction() public returns(bytes4) {
+        return bytes4(keccak256("configure(address)"));
+    }
+
+    function getPermissions() public view returns(bytes32[]) {
+        bytes32[] memory allPermissions = new bytes32[](0);
+        return allPermissions;
+    }
+
+}

--- a/contracts/modules/TransferManager/SimpleDaicoTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/SimpleDaicoTransferManagerFactory.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.4.23;
+
+import "./SimpleDaicoTransferManager.sol";
+import "../../interfaces/IModuleFactory.sol";
+
+
+contract SimpleDaicoTransferManagerFactory is IModuleFactory {
+
+    constructor (address _polyAddress) public
+      IModuleFactory(_polyAddress)
+    {
+
+    }
+
+    function deploy(bytes _data) external returns(address) {
+        if(getCost() > 0)
+            require(polyToken.transferFrom(msg.sender, owner, getCost()), "Failed transferFrom because of sufficent Allowance is not provided");
+        SimpleDaicoTransferManager daicoTransferManager = new SimpleDaicoTransferManager(msg.sender, address(polyToken));
+        require(getSig(_data) == daicoTransferManager.getInitFunction(), "Provided data is not valid");
+        require(address(daicoTransferManager).call(_data), "Un-successfull call");
+        return address(daicoTransferManager);
+
+    }
+
+    function getCost() public view returns(uint256) {
+        return 0;
+    }
+
+    function getType() public view returns(uint8) {
+        return 2;
+    }
+
+    function getName() public view returns(bytes32) {
+        return "SimpleDaicoTransferManager";
+    }
+
+    function getDescription() public view returns(string) {
+        return "Rebalance token votes for DAICO module";
+    }
+
+    function getTitle() public view returns(string) {
+        return "Simple Daico Transfer Manager";
+    }
+
+    function getInstructions() public view returns(string) {
+        return "";
+    }
+
+    function getTags() public view returns(bytes32[]) {
+         bytes32[] memory availableTags = new bytes32[](2);
+        availableTags[0] = "Daico";
+        availableTags[1] = "Transfer Restriction";
+        return availableTags;
+    }
+
+}


### PR DESCRIPTION
Initial commit for simple daico modules.

List of new contracts:
`Fund/SimpleDaicoFund.sol`
`Fund/ISimpleDaicoFund.sol`
`Fund/SimpleDaicoFundFactory.sol`
`Governance/VoteGovernance.sol`
`TransferManager/SimpleDaicoTransferManager.sol`
`TransferManager/SimpleDaicoTransferManagerFactory.sol`

- Currently the `SimpleDaicoFund.sol` contract uses `burnFrom()` function as published in `StandardBurnableToken.sol` from OpenZeppelin. Needs to be adapted to the ST 20 burnable token.
- Vote rebalancing is done using a transfer manager in `SimpleDaicoTransferManager.sol` module.