### PR TITLE
Fix registry contract inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ## Added
 
 * Iterable list of investors available on-chain
-* STOs are pausable now. It is facilated by using the IPausable interface.
+* STOs are pausable now. It is facilated by using the Pausable contract.
 * ManualApprovalTransferManager - allows approval or blocking of explicit address pairs for transfers.
 * Module Factories now allow their owner to set 3 types of fees: Setup fee, Usage fee, Monthly fee.
 * Added Checkpoint feature to token. This allows the issuer to create snapshots of the token's balances and totalSupply to be used for casting votes or distributing dividends. Created CLI to demo this feature.
@@ -17,9 +17,9 @@ All notable changes to this project will be documented in this file.
 * Added multi-mint feature.
 * Event `LogGenerateModuleFromFactory` emitted at the level of ModuleFactory to log the creation of the module using the respective module factory.
 * Added registration fee of `250 POLY` for registering ticker or security token with registry contracts, fee can be changed using `changePolyRegistrationFee`.
-* Added IRegistry contract to handle setting and retrieving registration fee.
-* Added pausable feature to registry functions `registerTicker`, `generateSecurityToken`, `registerModule`, `addCustomSecurityToken`.
-* Added upgradability functionality with functions to change reference address between registry contracts.
+* Added ReclaimTokens contract to handle retrieving ERC20 Tokens sent to our contracts.
+* Added Pausable feature to registry functions `registerTicker`, `generateSecurityToken`, `registerModule`, `addCustomSecurityToken`.
+* Added Registry contract to handle upgradability functionality with a function to change the reference address between registry contracts.
 
 ## Changed
 

--- a/contracts/ModuleRegistry.sol
+++ b/contracts/ModuleRegistry.sol
@@ -4,8 +4,7 @@ import "./interfaces/IModuleRegistry.sol";
 import "./interfaces/IModuleFactory.sol";
 import "./interfaces/ISecurityToken.sol";
 import "./interfaces/ISecurityTokenRegistry.sol";
-import "./interfaces/IRegistry.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Registry.sol";
 
 /**
 * @title ModuleRegistry
@@ -13,7 +12,7 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 * Anyone can register modules, but only those "approved" by Polymath will be allowed to everyone.
 */
 
-contract ModuleRegistry is IModuleRegistry, IRegistry {
+contract ModuleRegistry is IModuleRegistry, Registry {
 
     // Mapping used to hold the type of module factory corresponds to the address of the Module factory contract
     mapping (address => uint8) public registry;

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.4.23;
 
-contract IPausable {
+contract Pausable {
 
     event Pause(uint256 _timestammp);
     event Unpause(uint256 _timestamp);
 
     bool public paused = false;
-   
+
     /**
     * @dev Modifier to make a function callable only when the contract is not paused.
     */

--- a/contracts/ReclaimTokens.sol
+++ b/contracts/ReclaimTokens.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.23;
+
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+
+contract ReclaimTokens is Ownable {
+
+    /**
+    * @dev Reclaim all ERC20Basic compatible tokens
+    * @param _tokenContract The address of the token contract
+    */
+    function reclaimERC20(address _tokenContract) external onlyOwner {
+        require(_tokenContract != address(0));
+        ERC20Basic token = ERC20Basic(_tokenContract);
+        uint256 balance = token.balanceOf(address(this));
+        require(token.transfer(owner, balance));
+    }
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,60 @@
+pragma solidity ^0.4.23;
+
+import "./Pausable.sol";
+import "./ReclaimTokens.sol";
+
+contract Registry is Pausable, ReclaimTokens {
+
+    /*
+    Valid Address Keys
+    tickerRegistry = getAddress("TickerRegistry")
+    securityTokenRegistry = getAddress("SecurityTokenRegistry")
+    moduleRegistry = getAddress("ModuleRegistry")
+    polyToken = getAddress("PolyToken")
+    */
+
+    mapping (bytes32 => address) public storedAddresses;
+    mapping (bytes32 => bool) public validAddressKeys;
+
+    event LogChangeAddress(string _nameKey, address indexed _oldAddress, address indexed _newAddress);
+
+    /**
+     * @dev get the contract address
+     * @param _nameKey is the key for the contract address mapping
+     */
+    function getAddress(string _nameKey) public returns(address) {
+        require(validAddressKeys[keccak256(_nameKey)]);
+        return storedAddresses[keccak256(_nameKey)];
+    }
+
+    /**
+     * @dev change the contract address
+     * @param _nameKey is the key for the contract address mapping
+     * @param _newAddress is the new contract address
+     */
+    function changeAddress(string _nameKey, address _newAddress) public onlyOwner {
+        address oldAddress;
+        if (validAddressKeys[keccak256(_nameKey)]) {
+            oldAddress = getAddress(_nameKey);
+        } else {
+            validAddressKeys[keccak256(_nameKey)] = true;
+        }
+        storedAddresses[keccak256(_nameKey)] = _newAddress;
+        emit LogChangeAddress(_nameKey, oldAddress, _newAddress);
+    }
+
+    /**
+     * @dev pause (overridden function)
+     */
+    function unpause() public onlyOwner  {
+        super._unpause();
+    }
+
+    /**
+     * @dev unpause (overridden function)
+     */
+    function pause() public onlyOwner {
+        super._pause();
+    }
+
+}

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -4,12 +4,15 @@ import "./interfaces/ITickerRegistry.sol";
 import "./tokens/SecurityToken.sol";
 import "./interfaces/ISTProxy.sol";
 import "./interfaces/ISecurityTokenRegistry.sol";
-import "./interfaces/IRegistry.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./Registry.sol";
 import "./helpers/Util.sol";
 
-contract SecurityTokenRegistry is ISecurityTokenRegistry, Util, IRegistry {
+contract SecurityTokenRegistry is ISecurityTokenRegistry, Util, Registry {
+
+    // Registration fee in POLY base 18 decimals
+    uint256 public registrationFee;
+    // Emit when changePolyRegisterationFee is called
+    event LogChangePolyRegisterationFee(uint256 _oldFee, uint256 _newFee);
 
     // Emit at the time of launching of new security token
     event LogNewSecurityToken(string _ticker, address indexed _securityTokenAddress, address _owner);
@@ -126,4 +129,15 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, Util, IRegistry {
     function isSecurityToken(address _securityToken) public view returns (bool) {
         return (keccak256(securityTokens[_securityToken].symbol) != keccak256(""));
     }
+
+    /**
+     * @dev set the ticker registration fee in POLY tokens
+     * @param _registrationFee registration fee in POLY tokens (base 18 decimals)
+     */
+    function changePolyRegisterationFee(uint256 _registrationFee) public onlyOwner {
+        require(registrationFee != _registrationFee);
+        emit LogChangePolyRegisterationFee(registrationFee, _registrationFee);
+        registrationFee = _registrationFee;
+    }
+
 }

--- a/contracts/TickerRegistry.sol
+++ b/contracts/TickerRegistry.sol
@@ -7,10 +7,9 @@ pragma solidity ^0.4.23;
 */
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./interfaces/ITickerRegistry.sol";
-import "./interfaces/IRegistry.sol";
+import "./Registry.sol";
 import "./helpers/Util.sol";
 
 /**
@@ -18,7 +17,7 @@ import "./helpers/Util.sol";
  * @dev Contract used to register the security token symbols
  */
 
-contract TickerRegistry is ITickerRegistry, Util, IRegistry {
+contract TickerRegistry is ITickerRegistry, Util, Registry {
 
     using SafeMath for uint256;
     // constant variable to check the validity to use the symbol
@@ -41,6 +40,11 @@ contract TickerRegistry is ITickerRegistry, Util, IRegistry {
     event LogRegisterTicker(address indexed _owner, string _symbol, string _name, bytes32 _swarmHash, uint256 indexed _timestamp);
     // Emit when the token symbol expiry get changed
     event LogChangeExpiryLimit(uint256 _oldExpiry, uint256 _newExpiry);
+
+    // Registration fee in POLY base 18 decimals
+    uint256 public registrationFee;
+    // Emit when changePolyRegisterationFee is called
+    event LogChangePolyRegisterationFee(uint256 _oldFee, uint256 _newFee);
 
     constructor (address _polyToken, uint256 _registrationFee) public {
         changeAddress("PolyToken", _polyToken);
@@ -150,5 +154,15 @@ contract TickerRegistry is ITickerRegistry, Util, IRegistry {
                 return false;
         }
         return true;
+    }
+
+    /**
+     * @dev set the ticker registration fee in POLY tokens
+     * @param _registrationFee registration fee in POLY tokens (base 18 decimals)
+     */
+    function changePolyRegisterationFee(uint256 _registrationFee) public onlyOwner {
+        require(registrationFee != _registrationFee);
+        emit LogChangePolyRegisterationFee(registrationFee, _registrationFee);
+        registrationFee = _registrationFee;
     }
 }

--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -1,86 +1,28 @@
 pragma solidity ^0.4.23;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
-import "./IPausable.sol";
-
-contract IRegistry is Ownable, IPausable {
-
-    /*
-    Valid Address Keys
-    tickerRegistry = getAddress("TickerRegistry")
-    securityTokenRegistry = getAddress("SecurityTokenRegistry")
-    moduleRegistry = getAddress("ModuleRegistry")
-    polyToken = getAddress("PolyToken")
-    */
-
-    // Registration fee in POLY base 18 decimals
-    uint256 public registrationFee;
-
-    mapping (bytes32 => address) public storedAddresses;
-    mapping (bytes32 => bool) public validAddressKeys;
-
-    event LogChangePolyRegisterationFee(uint256 _oldFee, uint256 _newFee);
-    event LogChangeAddress(string _nameKey, address indexed _oldAddress, address indexed _newAddress);
+contract IRegistry {
 
     /**
      * @dev get the contract address
      * @param _nameKey is the key for the contract address mapping
      */
-    function getAddress(string _nameKey) public returns(address) {
-        require(validAddressKeys[keccak256(_nameKey)]);
-        return storedAddresses[keccak256(_nameKey)];
-    }
+    function getAddress(string _nameKey) public returns(address);
 
     /**
      * @dev change the contract address
      * @param _nameKey is the key for the contract address mapping
      * @param _newAddress is the new contract address
      */
-    function changeAddress(string _nameKey, address _newAddress) public onlyOwner {
-        address oldAddress;
-        if (validAddressKeys[keccak256(_nameKey)]) {
-            oldAddress = getAddress(_nameKey);
-        } else {
-            validAddressKeys[keccak256(_nameKey)] = true;
-        }
-        storedAddresses[keccak256(_nameKey)] = _newAddress;
-        emit LogChangeAddress(_nameKey, oldAddress, _newAddress);
-    }
-
-    /**
-    * @dev Reclaim all ERC20Basic compatible tokens
-    * @param _tokenContract The address of the token contract
-    */
-    function reclaimERC20(address _tokenContract) external onlyOwner {
-        require(_tokenContract != address(0));
-        ERC20Basic token = ERC20Basic(_tokenContract);
-        uint256 balance = token.balanceOf(address(this));
-        require(token.transfer(owner, balance));
-    }
-
-    /**
-     * @dev set the ticker registration fee in POLY tokens
-     * @param _registrationFee registration fee in POLY tokens (base 18 decimals)
-     */
-    function changePolyRegisterationFee(uint256 _registrationFee) public onlyOwner {
-        require(registrationFee != _registrationFee);
-        emit LogChangePolyRegisterationFee(registrationFee, _registrationFee);
-        registrationFee = _registrationFee;
-    }
+    function changeAddress(string _nameKey, address _newAddress) public;
 
     /**
      * @dev pause (overridden function)
      */
-    function unpause() public onlyOwner  {
-        super._unpause();
-    }
+    function unpause() public;
 
     /**
      * @dev unpause (overridden function)
      */
-    function pause() public onlyOwner {
-        super._pause();
-    }
+    function pause() public;
 
 }

--- a/contracts/interfaces/ISecurityTokenRegistry.sol
+++ b/contracts/interfaces/ISecurityTokenRegistry.sol
@@ -26,9 +26,6 @@ contract ISecurityTokenRegistry {
 
     function setProtocolVersion(address _stVersionProxyAddress, bytes32 _version) public;
 
-    //////////////////////////////
-    ///////// Get Functions
-    //////////////////////////////
     /**
      * @dev Get security token address by ticker name
      * @param _symbol Symbol of the Scurity token

--- a/contracts/modules/STO/ISTO.sol
+++ b/contracts/modules/STO/ISTO.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.4.23;
 
-import "../../interfaces/IPausable.sol";
+import "../../Pausable.sol";
 import "../../interfaces/IModule.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-contract ISTO is IModule, IPausable {
+contract ISTO is IModule, Pausable {
 
     using SafeMath for uint256;
 
@@ -27,7 +27,7 @@ contract ISTO is IModule, IPausable {
     }
 
     /**
-     * @notice Return ETH raised by the STO 
+     * @notice Return ETH raised by the STO
      */
     function getRaisedEther() public view returns (uint256);
 
@@ -37,7 +37,7 @@ contract ISTO is IModule, IPausable {
     function getRaisedPOLY() public view returns (uint256);
 
     /**
-     * @notice Return the total no. of investors 
+     * @notice Return the total no. of investors
      */
     function getNumberInvestors() public view returns (uint256);
 

--- a/contracts/modules/TransferManager/ITransferManager.sol
+++ b/contracts/modules/TransferManager/ITransferManager.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.23;
 
-import "../../interfaces/IPausable.sol";
+import "../../Pausable.sol";
 import "../../interfaces/IModule.sol";
 
-contract ITransferManager is IModule, IPausable {
+contract ITransferManager is IModule, Pausable {
 
     //If verifyTransfer returns:
     //  FORCE_VALID, the transaction will always be valid, regardless of other TM results

--- a/test/module_registry.js
+++ b/test/module_registry.js
@@ -508,33 +508,6 @@ contract('ModuleRegistry', accounts => {
 
     describe("Test cases for IRegistry functionality", async() => {
 
-        describe("Test cases for the changePolyRegisterationFee", async() => {
-
-            it("Should successfully get the registration fee", async() => {
-                let fee = await I_ModuleRegistry.registrationFee.call();
-                assert.equal(fee, 0)
-            });
-
-            it("Should fail to change the registration fee if msg.sender not owner", async() => {
-                let errorThrown = false;
-                try {
-                    let tx = await I_ModuleRegistry.changePolyRegisterationFee(400 * Math.pow(10, 18), { from: account_temp });
-                } catch(error) {
-                    console.log(`         tx revert -> Failed to change registrationFee`.grey);
-                    errorThrown = true;
-                    ensureException(error);
-                }
-                assert.ok(errorThrown, message);
-            });
-
-            it("Should successfully change the registration fee", async() => {
-                await I_ModuleRegistry.changePolyRegisterationFee(400 * Math.pow(10, 18), { from: account_polymath });
-                let fee = await I_ModuleRegistry.registrationFee.call();
-                assert.equal(fee, 400 * Math.pow(10, 18));
-            });
-
-        });
-
         describe("Test cases for reclaiming funds", async() => {
 
             it("Should successfully reclaim POLY tokens", async() => {


### PR DESCRIPTION
Here is how inheritance now works:
![inheritance](https://user-images.githubusercontent.com/15959632/41372225-ede2f4a8-6f4c-11e8-95fb-5d3b0b41c401.png)

I've pulled `IPausable` and `IRegistry` from interfaces folder.