### PR TITLE
Update to OpenZeppelin 1.10, truffle 4.1.11 & solc 0.4.24

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 
 contract Migrations {
@@ -12,7 +12,7 @@ contract Migrations {
         _;
     }
 
-    function Migrations() public {
+    constructor() public {
         owner = msg.sender;
     }
 

--- a/contracts/ModuleRegistry.sol
+++ b/contracts/ModuleRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./interfaces/IModuleRegistry.sol";
 import "./interfaces/IModuleFactory.sol";

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Utility contract to allow pausing and unpausing of certain functions

--- a/contracts/ReclaimTokens.sol
+++ b/contracts/ReclaimTokens.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./Pausable.sol";
 import "./ReclaimTokens.sol";
@@ -28,8 +28,8 @@ contract Registry is IRegistry, Pausable, ReclaimTokens {
      * @return address
      */
     function getAddress(string _nameKey) view public returns(address) {
-        require(validAddressKeys[keccak256(_nameKey)]);
-        return storedAddresses[keccak256(_nameKey)];
+        require(validAddressKeys[keccak256(bytes(_nameKey))]);
+        return storedAddresses[keccak256(bytes(_nameKey))];
     }
 
     /**
@@ -39,12 +39,12 @@ contract Registry is IRegistry, Pausable, ReclaimTokens {
      */
     function changeAddress(string _nameKey, address _newAddress) public onlyOwner {
         address oldAddress;
-        if (validAddressKeys[keccak256(_nameKey)]) {
+        if (validAddressKeys[keccak256(bytes(_nameKey))]) {
             oldAddress = getAddress(_nameKey);
         } else {
-            validAddressKeys[keccak256(_nameKey)] = true;
+            validAddressKeys[keccak256(bytes(_nameKey))] = true;
         }
-        storedAddresses[keccak256(_nameKey)] = _newAddress;
+        storedAddresses[keccak256(bytes(_nameKey))] = _newAddress;
         emit LogChangeAddress(_nameKey, oldAddress, _newAddress);
     }
 

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./interfaces/ITickerRegistry.sol";
 import "./tokens/SecurityToken.sol";
@@ -129,7 +129,7 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, Util, Registry {
     * @return bool
     */
     function isSecurityToken(address _securityToken) public view returns (bool) {
-        return (keccak256(securityTokens[_securityToken].symbol) != keccak256(""));
+        return (keccak256(bytes(securityTokens[_securityToken].symbol)) != keccak256(""));
     }
 
     /**

--- a/contracts/TickerRegistry.sol
+++ b/contracts/TickerRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/helpers/PolyToken.sol
+++ b/contracts/helpers/PolyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 

--- a/contracts/helpers/Util.sol
+++ b/contracts/helpers/Util.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Utility contract for reusable code

--- a/contracts/interfaces/IModule.sol
+++ b/contracts/interfaces/IModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ISecurityToken.sol";
 import "./IModuleFactory.sol";

--- a/contracts/interfaces/IModuleFactory.sol
+++ b/contracts/interfaces/IModuleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/interfaces/IModuleRegistry.sol
+++ b/contracts/interfaces/IModuleRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Interface for the polymath module registry contract

--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Interface for all polymath registry contracts

--- a/contracts/interfaces/IST20.sol
+++ b/contracts/interfaces/IST20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";

--- a/contracts/interfaces/ISTProxy.sol
+++ b/contracts/interfaces/ISTProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Interface for security token proxy deployment

--- a/contracts/interfaces/ISecurityToken.sol
+++ b/contracts/interfaces/ISecurityToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./IST20.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";

--- a/contracts/interfaces/ISecurityTokenRegistry.sol
+++ b/contracts/interfaces/ISecurityTokenRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ISecurityToken.sol";
 

--- a/contracts/interfaces/ITickerRegistry.sol
+++ b/contracts/interfaces/ITickerRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Interface for the polymath ticker registry contract

--- a/contracts/interfaces/ITokenBurner.sol
+++ b/contracts/interfaces/ITokenBurner.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 /**
  * @title Interface for the token burner contract

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../modules/STO/DummySTO.sol";
 import "../interfaces/IModuleFactory.sol";

--- a/contracts/mocks/PolyTokenFaucet.sol
+++ b/contracts/mocks/PolyTokenFaucet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 

--- a/contracts/mocks/TestSTOFactory.sol
+++ b/contracts/mocks/TestSTOFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../modules/STO/DummySTO.sol";
 import "../interfaces/IModuleFactory.sol";

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ICheckpoint.sol";
 import "../../interfaces/ISecurityToken.sol";

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ERC20DividendCheckpoint.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ICheckpoint.sol";
 import "../../interfaces/ISecurityToken.sol";

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./EtherDividendCheckpoint.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/Checkpoint/ICheckpoint.sol
+++ b/contracts/modules/Checkpoint/ICheckpoint.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../../interfaces/IModule.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";

--- a/contracts/modules/PermissionManager/GeneralPermissionManager.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./IPermissionManager.sol";
 

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./GeneralPermissionManager.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/PermissionManager/IPermissionManager.sol
+++ b/contracts/modules/PermissionManager/IPermissionManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../../interfaces/IModule.sol";
 

--- a/contracts/modules/STO/CappedSTO.sol
+++ b/contracts/modules/STO/CappedSTO.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ISTO.sol";
 import "../../interfaces/IST20.sol";

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "./CappedSTO.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/STO/DummySTO.sol
+++ b/contracts/modules/STO/DummySTO.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ISTO.sol";
 import "../../interfaces/IST20.sol";

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./DummySTO.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/STO/ISTO.sol
+++ b/contracts/modules/STO/ISTO.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../../Pausable.sol";
 import "../../interfaces/IModule.sol";

--- a/contracts/modules/STO/PreSaleSTO.sol
+++ b/contracts/modules/STO/PreSaleSTO.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ISTO.sol";
 import "../../interfaces/IST20.sol";

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./PreSaleSTO.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/TransferManager/CountTransferManager.sol
+++ b/contracts/modules/TransferManager/CountTransferManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ITransferManager.sol";
 

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./CountTransferManager.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/TransferManager/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ITransferManager.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -253,7 +253,7 @@ contract GeneralTransferManager is ITransferManager {
     ) public {
         require(_validFrom <= now, "ValidFrom is too early");
         require(_validTo >= now, "ValidTo is too late");
-        bytes32 hash = keccak256(this, _investor, _fromTime, _toTime, _expiryTime, _canBuyFromSTO, _validFrom, _validTo);
+        bytes32 hash = keccak256(abi.encodePacked(this, _investor, _fromTime, _toTime, _expiryTime, _canBuyFromSTO, _validFrom, _validTo));
         checkSig(hash, _v, _r, _s);
         //Passing a _time == 0 into this function, is equivalent to removing the _investor from the whitelist
         whitelist[_investor] = TimeRestriction(_fromTime, _toTime, _expiryTime, _canBuyFromSTO);
@@ -266,7 +266,7 @@ contract GeneralTransferManager is ITransferManager {
     function checkSig(bytes32 _hash, uint8 _v, bytes32 _r, bytes32 _s) internal view {
         //Check that the signature is valid
         //sig should be signing - _investor, _fromTime, _toTime & _expiryTime and be signed by the issuer address
-        address signer = ecrecover(keccak256("\x19Ethereum Signed Message:\n32", _hash), _v, _r, _s);
+        address signer = ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash)), _v, _r, _s);
         require(signer == ISecurityToken(securityToken).owner() || signer == signingAddress, "Incorrect signer");
     }
 

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./GeneralTransferManager.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/TransferManager/ITransferManager.sol
+++ b/contracts/modules/TransferManager/ITransferManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../../Pausable.sol";
 import "../../interfaces/IModule.sol";

--- a/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ITransferManager.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ManualApprovalTransferManager.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/modules/TransferManager/PercentageTransferManager.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./ITransferManager.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./PercentageTransferManager.sol";
 import "../../interfaces/IModuleFactory.sol";

--- a/contracts/tokens/STVersionProxy001.sol
+++ b/contracts/tokens/STVersionProxy001.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./SecurityToken.sol";
 import "../SecurityTokenRegistry.sol";

--- a/contracts/tokens/STVersionProxy002.sol
+++ b/contracts/tokens/STVersionProxy002.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./SecurityTokenV2.sol";
 import "../SecurityTokenRegistry.sol";

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/math/Math.sol";

--- a/contracts/tokens/SecurityTokenV2.sol
+++ b/contracts/tokens/SecurityTokenV2.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./SecurityToken.sol";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7582,9 +7582,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "deep-assign": "2.0.0",
         "fs-extra": "5.0.0",
         "shelljs": "0.8.2",
-        "solc": "0.4.19",
+        "solc": "0.4.24",
         "valid-url": "1.0.9",
         "yargs": "11.0.0"
       },
@@ -6085,12 +6085,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -6570,78 +6564,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "log-driver": {
       "version": "1.2.7",
@@ -7108,76 +7034,63 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
           "dev": true
         },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
         },
         "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -8998,9 +8911,9 @@
       }
     },
     "solc": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.19.tgz",
-      "integrity": "sha512-hvi/vi9rQcB73poRLoLRfQIYKwmdhrNbZlOOFCGd5v58gEsYEUr3+oHPSXhyk4CFNchWC2ojpMYrHDJNm0h4jQ==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -10303,214 +10216,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.7.tgz",
-      "integrity": "sha512-fe6BIcD9xo6iIJvV1m6ZhOk56kmB8k38kdoWOKYnPPw7ZUUSupgojeTb2K5e+4qIpIHvEvmET4yLUjSGR+hvwA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
+      "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
       "dev": true,
       "requires": {
-        "mocha": "3.5.3",
+        "mocha": "4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.23"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "solc": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
-          "integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "0.30.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "1.2.1",
-            "semver": "5.5.0",
-            "yargs": "4.8.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "dev": true,
-          "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "lodash.assign": "4.2.0",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "2.4.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
-          }
-        }
+        "solc": "0.4.24"
       }
     },
     "truffle-blockchain-utils": {
@@ -10660,7 +10373,7 @@
             "readable-stream": "2.3.5",
             "request": "2.85.0",
             "semaphore": "1.1.0",
-            "solc": "0.4.19",
+            "solc": "0.4.24",
             "tape": "4.9.0",
             "xhr": "2.4.1",
             "xtend": "4.0.1"
@@ -11768,7 +11481,7 @@
         "isomorphic-fetch": "2.2.1",
         "request": "2.85.0",
         "semaphore": "1.1.0",
-        "solc": "0.4.19",
+        "solc": "0.4.24",
         "tape": "4.9.0",
         "web3": "0.16.0",
         "xhr": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "coveralls": "^3.0.1",
     "ethereumjs-testrpc": "^6.0.3",
     "ethers": "^3.0.15",
-    "openzeppelin-solidity": "^1.9.0",
+    "openzeppelin-solidity": "1.10.0",
     "readline-sync": "^1.4.9",
     "shelljs": "^0.8.2",
     "truffle-contract": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "openzeppelin-solidity": "1.10.0",
     "readline-sync": "^1.4.9",
     "shelljs": "^0.8.2",
+    "solc": "^0.4.24",
     "truffle-contract": "^3.0.4",
     "truffle-hdwallet-provider-privkey": "^0.1.0",
     "web3": "^1.0.0-beta.33"
@@ -75,7 +76,7 @@
     "sol-merger": "^0.1.2",
     "solidity-coverage": "^0.5.0",
     "solium": "^1.1.6",
-    "truffle": "^4.1.7",
+    "truffle": "^4.1.11",
     "truffle-wallet-provider": "0.0.5"
   }
 }

--- a/test/helpers/contracts/PolyToken.sol
+++ b/test/helpers/contracts/PolyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
 

--- a/test/helpers/contracts/TokenBurner.sol
+++ b/test/helpers/contracts/TokenBurner.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "../../../contracts/interfaces/ISecurityToken.sol";
 import "../../../contracts/interfaces/ITokenBurner.sol";


### PR DESCRIPTION
- Update to OZ 1.10 did not raise any issues, tests still successful
- Update to truffle 4.1.11 & solc 0.4.24
    - Changed Migrations.sol constructor from named function to constructor()
    - Changed all contracts to pragma solidity 0.4.24;
    - Added keccak256(bytes()) or keccak256(abi.encodePacked()) according to https://github.com/ethereum/solidity/issues/3955 