### PR TITLE
Add test for concurrent STOs

### DIFF
--- a/test/capped_sto.js
+++ b/test/capped_sto.js
@@ -51,10 +51,8 @@ contract('CappedSTO', accounts => {
     let I_STVersion;
     let I_SecurityToken_ETH;
     let I_SecurityToken_POLY;
-    let I_CappedSTO_ETH1;
-    let I_CappedSTO_ETH2;
-    let I_CappedSTO_POLY1;
-    let I_CappedSTO_POLY2;
+    let I_CappedSTO_Array_ETH = [];
+    let I_CappedSTO_Array_POLY = [];
     let I_PolyToken;
 
     // SecurityToken Details for funds raise Type ETH
@@ -357,7 +355,7 @@ contract('CappedSTO', accounts => {
 
             assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
             assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
-            I_CappedSTO_ETH1 = CappedSTO.at(tx.logs[3].args._module);
+            I_CappedSTO_Array_ETH.push(CappedSTO.at(tx.logs[3].args._module));
         });
     });
 
@@ -365,27 +363,27 @@ contract('CappedSTO', accounts => {
 
         it("Should verify the configuration of the STO", async() => {
             assert.equal(
-                await I_CappedSTO_ETH1.startTime.call(),
+                await I_CappedSTO_Array_ETH[0].startTime.call(),
                 startTime_ETH1,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH1.endTime.call(),
+                await I_CappedSTO_Array_ETH[0].endTime.call(),
                 endTime_ETH1,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                (await I_CappedSTO_ETH1.cap.call()).toNumber(),
+                (await I_CappedSTO_Array_ETH[0].cap.call()).toNumber(),
                 cap,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH1.rate.call(),
+                await I_CappedSTO_Array_ETH[0].rate.call(),
                 rate,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH1.fundraiseType.call(),
+                await I_CappedSTO_Array_ETH[0].fundraiseType.call(),
                 fundRaiseType,
                 "STO Configuration doesn't set as expected"
             );
@@ -399,7 +397,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     value: web3.utils.toWei('1', 'ether')
                   });
             } catch(error) {
@@ -415,7 +413,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     value: web3.utils.toWei('0', 'ether')
                   });
             } catch(error) {
@@ -431,7 +429,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     value: web3.utils.toWei('1', 'ether')
                   });
             } catch(error) {
@@ -447,7 +445,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     value: web3.utils.toWei('0.1111', 'ether')
                   });
             } catch(error) {
@@ -480,19 +478,19 @@ contract('CappedSTO', accounts => {
             // Fallback transaction
             await web3.eth.sendTransaction({
                 from: account_investor1,
-                to: I_CappedSTO_ETH1.address,
+                to: I_CappedSTO_Array_ETH[0].address,
                 gas: 2100000,
                 value: web3.utils.toWei('1', 'ether')
               });
 
             assert.equal(
-                (await I_CappedSTO_ETH1.fundsRaised.call())
+                (await I_CappedSTO_Array_ETH[0].fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 1
             );
 
-            assert.equal(await I_CappedSTO_ETH1.getNumberInvestors.call(), 1);
+            assert.equal(await I_CappedSTO_Array_ETH[0].getNumberInvestors.call(), 1);
 
             assert.equal(
                 (await I_SecurityToken_ETH.balanceOf(account_investor1))
@@ -503,7 +501,7 @@ contract('CappedSTO', accounts => {
         });
 
         it("Verification of the event Token Purchase", async() => {
-            let TokenPurchase = I_CappedSTO_ETH1.allEvents();
+            let TokenPurchase = I_CappedSTO_Array_ETH[0].allEvents();
             let log = await new Promise(function(resolve, reject) {
                 TokenPurchase.watch(function(error, log){ resolve(log);})
             });
@@ -522,7 +520,7 @@ contract('CappedSTO', accounts => {
         it("Should pause the STO -- Failed due to wrong msg.sender", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO_ETH1.pause({from: account_investor1});
+                let tx = await I_CappedSTO_Array_ETH[0].pause({from: account_investor1});
             } catch(error) {
                 console.log(`         tx revert -> Wrong msg.sender`.grey);
                 ensureException(error);
@@ -532,8 +530,8 @@ contract('CappedSTO', accounts => {
         });
 
         it("Should pause the STO", async()=> {
-            let tx = await I_CappedSTO_ETH1.pause({from: account_issuer});
-            assert.isTrue(await I_CappedSTO_ETH1.paused.call());
+            let tx = await I_CappedSTO_Array_ETH[0].pause({from: account_issuer});
+            assert.isTrue(await I_CappedSTO_Array_ETH[0].paused.call());
         });
 
         it("Should fail to buy the tokens after pausing the STO", async() => {
@@ -541,7 +539,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     gas: 2100000,
                     value: web3.utils.toWei('1', 'ether')
                   });
@@ -556,7 +554,7 @@ contract('CappedSTO', accounts => {
         it("Should unpause the STO -- Failed due to wrong msg.sender", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO_ETH1.unpause(Math.floor(Date.now()/1000 + 50000), {from: account_investor1});
+                let tx = await I_CappedSTO_Array_ETH[0].unpause(Math.floor(Date.now()/1000 + 50000), {from: account_investor1});
             } catch(error) {
                 console.log(`         tx revert -> Wrong msg.sender`.grey);
                 ensureException(error);
@@ -568,7 +566,7 @@ contract('CappedSTO', accounts => {
         it("Should unpause the STO -- Failed due to entered date is less than the end date", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO_ETH1.unpause(Math.floor(Date.now()/1000 - 500000), {from: account_issuer});
+                let tx = await I_CappedSTO_Array_ETH[0].unpause(Math.floor(Date.now()/1000 - 500000), {from: account_issuer});
             } catch(error) {
                 console.log(`         tx revert -> Entered date is less than the end date`.grey);
                 ensureException(error);
@@ -579,9 +577,9 @@ contract('CappedSTO', accounts => {
 
         it("Should unpause the STO", async()=> {
             await increaseTime(50);
-            let newEndDate = ((await I_CappedSTO_ETH1.endTime.call()).toNumber() - latestTime()) + latestTime() + 20;
-            let tx = await I_CappedSTO_ETH1.unpause(newEndDate, {from: account_issuer});
-            assert.isFalse(await I_CappedSTO_ETH1.paused.call());
+            let newEndDate = ((await I_CappedSTO_Array_ETH[0].endTime.call()).toNumber() - latestTime()) + latestTime() + 20;
+            let tx = await I_CappedSTO_Array_ETH[0].unpause(newEndDate, {from: account_issuer});
+            assert.isFalse(await I_CappedSTO_Array_ETH[0].paused.call());
         });
 
         it("Should buy the tokens -- Failed due to wrong granularity", async () => {
@@ -589,7 +587,7 @@ contract('CappedSTO', accounts => {
             try {
                  await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO_ETH1.address,
+                    to: I_CappedSTO_Array_ETH[0].address,
                     value: web3.utils.toWei('0.1111', 'ether')
                   });
             } catch(error) {
@@ -617,19 +615,19 @@ contract('CappedSTO', accounts => {
              // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO_ETH1.address,
+                to: I_CappedSTO_Array_ETH[0].address,
                 gas: 2100000,
                 value: web3.utils.toWei('9', 'ether')
               });
 
               assert.equal(
-                (await I_CappedSTO_ETH1.fundsRaised.call())
+                (await I_CappedSTO_Array_ETH[0].fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 10
             );
 
-            assert.equal(await I_CappedSTO_ETH1.getNumberInvestors.call(), 2);
+            assert.equal(await I_CappedSTO_Array_ETH[0].getNumberInvestors.call(), 2);
 
             assert.equal(
                 (await I_SecurityToken_ETH.balanceOf(account_investor2))
@@ -641,7 +639,7 @@ contract('CappedSTO', accounts => {
                 // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO_ETH1.address,
+                to: I_CappedSTO_Array_ETH[0].address,
                 gas: 210000,
                 value: web3.utils.toWei('1', 'ether')
               });
@@ -658,7 +656,7 @@ contract('CappedSTO', accounts => {
                 // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO_ETH1.address,
+                to: I_CappedSTO_Array_ETH[0].address,
                 gas: 2100000,
                 value: web3.utils.toWei('1', 'ether')
               });
@@ -675,18 +673,18 @@ contract('CappedSTO', accounts => {
             //console.log("WWWW",newBalance,await I_CappedSTO.fundsRaised.call(),balanceOfReceiver);
             let op = (BigNumber(newBalance).minus(balanceOfReceiver)).toNumber();
             assert.equal(
-                (await I_CappedSTO_ETH1.fundsRaised.call()).toNumber(),
+                (await I_CappedSTO_Array_ETH[0].fundsRaised.call()).toNumber(),
                 op,
                 "Somewhere raised money get stolen or sent to wrong wallet"
             );
         });
 
         it("Should get the raised amount of ether", async() => {
-            assert.equal(await I_CappedSTO_ETH1.getRaisedEther.call(), web3.utils.toWei('10','ether'));
+            assert.equal(await I_CappedSTO_Array_ETH[0].getRaisedEther.call(), web3.utils.toWei('10','ether'));
         });
 
         it("Should get the raised amount of poly", async() => {
-            assert.equal((await I_CappedSTO_ETH1.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('0','ether'));
+            assert.equal((await I_CappedSTO_Array_ETH[0].getRaisedPOLY.call()).toNumber(), web3.utils.toWei('0','ether'));
          });
 
     });
@@ -704,32 +702,32 @@ contract('CappedSTO', accounts => {
 
             assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
             assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
-            I_CappedSTO_ETH2 = CappedSTO.at(tx.logs[3].args._module);
+            I_CappedSTO_Array_ETH.push(CappedSTO.at(tx.logs[3].args._module));
         });
 
         it("Should verify the configuration of the STO", async() => {
             assert.equal(
-                await I_CappedSTO_ETH2.startTime.call(),
+                await I_CappedSTO_Array_ETH[1].startTime.call(),
                 startTime_ETH2,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH2.endTime.call(),
+                await I_CappedSTO_Array_ETH[1].endTime.call(),
                 endTime_ETH2,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                (await I_CappedSTO_ETH2.cap.call()).toNumber(),
+                (await I_CappedSTO_Array_ETH[1].cap.call()).toNumber(),
                 cap,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH2.rate.call(),
+                await I_CappedSTO_Array_ETH[1].rate.call(),
                 rate,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_ETH2.fundraiseType.call(),
+                await I_CappedSTO_Array_ETH[1].fundraiseType.call(),
                 fundRaiseType,
                 "STO Configuration doesn't set as expected"
             );
@@ -755,16 +753,16 @@ contract('CappedSTO', accounts => {
             // Jump time to beyond STO start
             await increaseTime(duration.days(2));
 
-            await I_CappedSTO_ETH2.buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
+            await I_CappedSTO_Array_ETH[1].buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
 
             assert.equal(
-                (await I_CappedSTO_ETH2.fundsRaised.call())
+                (await I_CappedSTO_Array_ETH[1].fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 1
             );
 
-            assert.equal(await I_CappedSTO_ETH2.getNumberInvestors.call(), 1);
+            assert.equal(await I_CappedSTO_Array_ETH[1].getNumberInvestors.call(), 1);
 
             assert.equal(
                 (await I_SecurityToken_ETH.balanceOf(account_investor3))
@@ -772,6 +770,49 @@ contract('CappedSTO', accounts => {
                 .toNumber(),
                 1000
             );
+        });
+    });
+
+    describe("Test cases for reaching limit number of STO modules", async() => {
+
+        it("Should successfully attach STO modules up to the limit and fail at the limit", async () => {
+            let startTime = latestTime() + duration.days(1);
+            let endTime = startTime + duration.days(30);
+
+            await I_PolyToken.getTokens(cappedSTOSetupCost*19, token_owner);
+            await I_PolyToken.transfer(I_SecurityToken_ETH.address, cappedSTOSetupCost*19, { from: token_owner});
+            let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime, endTime, cap, rate, fundRaiseType, account_fundsReceiver]);
+
+            for (var STOIndex = 2; STOIndex < 20; STOIndex++) {
+                const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner });
+                assert.equal(tx.logs[3].args._type, stoKey, `Wrong module type added at index ${STOIndex}`);
+                assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO",`Wrong STO module added at index ${STOIndex}`);
+                I_CappedSTO_Array_ETH.push(CappedSTO.at(tx.logs[3].args._module));
+            }
+
+            let errorThrown = false;
+            try {
+                 await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner });
+            } catch(error) {
+                console.log(`         tx revert -> reached cap number of modules attached`.grey);
+                ensureException(error);
+                errorThrown = true;
+            }
+            assert.ok(errorThrown, message);
+        });
+
+        it("Should successfully invest in all STO modules attached", async () => {
+            await increaseTime(duration.days(2));
+            for (var STOIndex = 2; STOIndex < 20; STOIndex++) {
+                await I_CappedSTO_Array_ETH[STOIndex].buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
+                assert.equal(
+                    (await I_CappedSTO_Array_ETH[STOIndex].fundsRaised.call())
+                    .dividedBy(new BigNumber(10).pow(18))
+                    .toNumber(),
+                    1
+                );
+                assert.equal(await I_CappedSTO_Array_ETH[STOIndex].getNumberInvestors.call(), 1);
+            }
         });
     });
 
@@ -831,7 +872,7 @@ contract('CappedSTO', accounts => {
 
                 assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
                 assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
-                I_CappedSTO_POLY1 = CappedSTO.at(tx.logs[3].args._module);
+                I_CappedSTO_Array_POLY.push(CappedSTO.at(tx.logs[3].args._module));
             });
 
         });
@@ -840,27 +881,27 @@ contract('CappedSTO', accounts => {
 
             it("Should verify the configuration of the STO", async() => {
                 assert.equal(
-                    (await I_CappedSTO_POLY1.startTime.call()).toNumber(),
+                    (await I_CappedSTO_Array_POLY[0].startTime.call()).toNumber(),
                     startTime_POLY1,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    (await I_CappedSTO_POLY1.endTime.call()).toNumber(),
+                    (await I_CappedSTO_Array_POLY[0].endTime.call()).toNumber(),
                     endTime_POLY1,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    (await I_CappedSTO_POLY1.cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
+                    (await I_CappedSTO_Array_POLY[0].cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
                     P_cap.dividedBy(new BigNumber(10).pow(18)),
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    await I_CappedSTO_POLY1.rate.call(),
+                    await I_CappedSTO_Array_POLY[0].rate.call(),
                     P_rate,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    await I_CappedSTO_POLY1.fundraiseType.call(),
+                    await I_CappedSTO_Array_POLY[0].fundraiseType.call(),
                     P_fundRaiseType,
                     "STO Configuration doesn't set as expected"
                 );
@@ -896,10 +937,10 @@ contract('CappedSTO', accounts => {
                 // Jump time
                 await increaseTime(duration.days(17));
 
-                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                await I_PolyToken.approve(I_CappedSTO_Array_POLY[0].address, (1000 * Math.pow(10, 18)), { from: account_investor1});
 
                 // buyTokensWithPoly transaction
-                await I_CappedSTO_POLY1.buyTokensWithPoly(
+                await I_CappedSTO_Array_POLY[0].buyTokensWithPoly(
                     (1000 * Math.pow(10, 18)),
                     {
                         from : account_investor1,
@@ -908,13 +949,13 @@ contract('CappedSTO', accounts => {
                 );
 
                 assert.equal(
-                    (await I_CappedSTO_POLY1.fundsRaised.call())
+                    (await I_CappedSTO_Array_POLY[0].fundsRaised.call())
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     1000
                 );
 
-                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(), 1);
+                assert.equal(await I_CappedSTO_Array_POLY[0].getNumberInvestors.call(), 1);
 
                 assert.equal(
                     (await I_SecurityToken_POLY.balanceOf(account_investor1))
@@ -925,7 +966,7 @@ contract('CappedSTO', accounts => {
             });
 
             it("Verification of the event Token Purchase", async() => {
-                let TokenPurchase = I_CappedSTO_POLY1.allEvents();
+                let TokenPurchase = I_CappedSTO_Array_POLY[0].allEvents();
                 let log = await new Promise(function(resolve, reject) {
                     TokenPurchase.watch(function(error, log){ resolve(log);})
                 });
@@ -957,22 +998,22 @@ contract('CappedSTO', accounts => {
 
                 await I_PolyToken.getTokens((10000 * Math.pow(10, 18)), account_investor2);
 
-                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (9000 * Math.pow(10, 18)), { from: account_investor2});
+                await I_PolyToken.approve(I_CappedSTO_Array_POLY[0].address, (9000 * Math.pow(10, 18)), { from: account_investor2});
 
                 // buyTokensWithPoly transaction
-                await I_CappedSTO_POLY1.buyTokensWithPoly(
+                await I_CappedSTO_Array_POLY[0].buyTokensWithPoly(
                     (9000 * Math.pow(10, 18)),
                     {from : account_investor2, gas: 6000000 }
                 );
 
                   assert.equal(
-                    (await I_CappedSTO_POLY1.fundsRaised.call())
+                    (await I_CappedSTO_Array_POLY[0].fundsRaised.call())
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     10000
                 );
 
-                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(), 2);
+                assert.equal(await I_CappedSTO_Array_POLY[0].getNumberInvestors.call(), 2);
 
                 assert.equal(
                     (await I_SecurityToken_POLY.balanceOf(account_investor2))
@@ -983,9 +1024,9 @@ contract('CappedSTO', accounts => {
                 let errorThrown = false;
                 try {
 
-                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                await I_PolyToken.approve(I_CappedSTO_Array_POLY[0].address, (1000 * Math.pow(10, 18)), { from: account_investor1});
                 // buyTokensWithPoly transaction
-                await I_CappedSTO_POLY1.buyTokensWithPoly(
+                await I_CappedSTO_Array_POLY[0].buyTokensWithPoly(
                     (1000 * Math.pow(10, 18)),
                     {from : account_investor1, gas: 6000000 }
                 );
@@ -1001,9 +1042,9 @@ contract('CappedSTO', accounts => {
                 await increaseTime(duration.days(31)); // increased beyond the end time of the STO
                 let errorThrown = false;
                 try {
-                    await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                    await I_PolyToken.approve(I_CappedSTO_Array_POLY[0].address, (1000 * Math.pow(10, 18)), { from: account_investor1});
                     // buyTokensWithPoly transaction
-                    await I_CappedSTO_POLY1.buyTokensWithPoly(
+                    await I_CappedSTO_Array_POLY[0].buyTokensWithPoly(
                         (1000 * Math.pow(10, 18)),
                         {from : account_investor1, gas: 6000000 }
                     );
@@ -1018,7 +1059,7 @@ contract('CappedSTO', accounts => {
             it("Should fundRaised value equal to the raised value in the funds receiver wallet", async() => {
                 const balanceRaised = await I_PolyToken.balanceOf.call(account_fundsReceiver);
                 assert.equal(
-                    (await I_CappedSTO_POLY1.fundsRaised.call()).toNumber(),
+                    (await I_CappedSTO_Array_POLY[0].fundsRaised.call()).toNumber(),
                     balanceRaised,
                     "Somewhere raised money get stolen or sent to wrong wallet"
                 );
@@ -1050,28 +1091,28 @@ contract('CappedSTO', accounts => {
 
          describe("Test cases for the get functions of the capped sto", async() => {
              it("Should verify the cap reached or not", async() => {
-                assert.isTrue(await I_CappedSTO_POLY1.capReached.call());
+                assert.isTrue(await I_CappedSTO_Array_POLY[0].capReached.call());
              });
 
              it("Should get the raised amount of ether", async() => {
-                assert.equal(await I_CappedSTO_POLY1.getRaisedEther.call(), web3.utils.toWei('0','ether'));
+                assert.equal(await I_CappedSTO_Array_POLY[0].getRaisedEther.call(), web3.utils.toWei('0','ether'));
              });
 
              it("Should get the raised amount of poly", async() => {
-                assert.equal((await I_CappedSTO_POLY1.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('10000','ether'));
+                assert.equal((await I_CappedSTO_Array_POLY[0].getRaisedPOLY.call()).toNumber(), web3.utils.toWei('10000','ether'));
              });
 
              it("Should get the investors", async() => {
-                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(),2);
+                assert.equal(await I_CappedSTO_Array_POLY[0].getNumberInvestors.call(),2);
              });
 
              it("Should get the listed permissions", async() => {
-                let tx = await I_CappedSTO_POLY1.getPermissions.call();
+                let tx = await I_CappedSTO_Array_POLY[0].getPermissions.call();
                 assert.equal(tx.length,0);
              });
 
              it("Should get the metrics of the STO", async() => {
-                let metrics = await I_CappedSTO_POLY1.getSTODetails.call();
+                let metrics = await I_CappedSTO_Array_POLY[0].getSTODetails.call();
                 assert.isTrue(metrics[7]);
              });
 
@@ -1092,32 +1133,32 @@ contract('CappedSTO', accounts => {
 
             assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
             assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
-            I_CappedSTO_POLY2 = CappedSTO.at(tx.logs[3].args._module);
+            I_CappedSTO_Array_POLY.push(CappedSTO.at(tx.logs[3].args._module));
         });
 
         it("Should verify the configuration of the STO", async() => {
             assert.equal(
-                (await I_CappedSTO_POLY2.startTime.call()).toNumber(),
+                (await I_CappedSTO_Array_POLY[1].startTime.call()).toNumber(),
                 startTime_POLY2,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                (await I_CappedSTO_POLY2.endTime.call()).toNumber(),
+                (await I_CappedSTO_Array_POLY[1].endTime.call()).toNumber(),
                 endTime_POLY2,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                (await I_CappedSTO_POLY2.cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
+                (await I_CappedSTO_Array_POLY[1].cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
                 P_cap.dividedBy(new BigNumber(10).pow(18)),
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_POLY2.rate.call(),
+                await I_CappedSTO_Array_POLY[1].rate.call(),
                 P_rate,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO_POLY2.fundraiseType.call(),
+                await I_CappedSTO_Array_POLY[1].fundraiseType.call(),
                 P_fundRaiseType,
                 "STO Configuration doesn't set as expected"
             );
@@ -1144,10 +1185,10 @@ contract('CappedSTO', accounts => {
             // Jump time to beyond STO start
             await increaseTime(duration.days(2));
 
-            await I_PolyToken.approve(I_CappedSTO_POLY2.address, (polyToInvest * Math.pow(10, 18)), { from: account_investor3 });
+            await I_PolyToken.approve(I_CappedSTO_Array_POLY[1].address, (polyToInvest * Math.pow(10, 18)), { from: account_investor3 });
 
             // buyTokensWithPoly transaction
-            await I_CappedSTO_POLY2.buyTokensWithPoly(
+            await I_CappedSTO_Array_POLY[1].buyTokensWithPoly(
                 (polyToInvest * Math.pow(10, 18)),
                 {
                     from : account_investor3,
@@ -1156,13 +1197,13 @@ contract('CappedSTO', accounts => {
             );
 
             assert.equal(
-                (await I_CappedSTO_POLY2.fundsRaised.call())
+                (await I_CappedSTO_Array_POLY[1].fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 polyToInvest
             );
 
-            assert.equal(await I_CappedSTO_POLY2.getNumberInvestors.call(), 1);
+            assert.equal(await I_CappedSTO_Array_POLY[1].getNumberInvestors.call(), 1);
 
             assert.equal(
                 (await I_SecurityToken_POLY.balanceOf(account_investor3))

--- a/test/capped_sto.js
+++ b/test/capped_sto.js
@@ -26,6 +26,7 @@ contract('CappedSTO', accounts => {
     let account_issuer;
     let token_owner;
     let account_investor2;
+    let account_investor3;
     let account_fundsReceiver;
 
     let balanceOfReceiver;
@@ -48,8 +49,12 @@ contract('CappedSTO', accounts => {
     let I_SecurityTokenRegistry;
     let I_CappedSTOFactory;
     let I_STVersion;
-    let I_SecurityToken;
-    let I_CappedSTO;
+    let I_SecurityToken_ETH;
+    let I_SecurityToken_POLY;
+    let I_CappedSTO_ETH1;
+    let I_CappedSTO_ETH2;
+    let I_CappedSTO_POLY1;
+    let I_CappedSTO_POLY2;
     let I_PolyToken;
 
     // SecurityToken Details for funds raise Type ETH
@@ -74,18 +79,24 @@ contract('CappedSTO', accounts => {
     const initRegFee = 250 * Math.pow(10, 18);
 
     // Capped STO details
-    let startTime;           // Start time will be 5000 seconds more than the latest time
-    let endTime;                     // Add 30 days more
+    let startTime_ETH1;
+    let endTime_ETH1;
+    let startTime_ETH2;
+    let endTime_ETH2;
     const cap = new BigNumber(10000).times(new BigNumber(10).pow(18));
     const rate = 1000;
     const fundRaiseType = 0;
+
+    let startTime_POLY1;
+    let endTime_POLY1;
+    let startTime_POLY2;
+    let endTime_POLY2;
     const P_cap = new BigNumber(50000).times(new BigNumber(10).pow(18));
     const P_fundRaiseType = 1;
     const P_rate = 5;
     const cappedSTOSetupCost= web3.utils.toWei("20000","ether");
     const maxCost = cappedSTOSetupCost;
-    let P_startTime = endTime + duration.days(2);
-    let P_endTime = P_startTime + duration.days(30);
+
     const functionSignature = {
         name: 'configure',
         type: 'function',
@@ -117,6 +128,7 @@ contract('CappedSTO', accounts => {
         account_issuer = accounts[1];
         account_investor1 = accounts[4];
         account_investor2 = accounts[3];
+        account_investor3 = accounts[5]
         account_fundsReceiver = accounts[2];
         token_owner = account_issuer;
 
@@ -249,25 +261,21 @@ contract('CappedSTO', accounts => {
             // Verify the successful generation of the security token
             assert.equal(tx.logs[1].args._ticker, symbol, "SecurityToken doesn't get deployed");
 
-            I_SecurityToken = SecurityToken.at(tx.logs[1].args._securityTokenAddress);
+            I_SecurityToken_ETH = SecurityToken.at(tx.logs[1].args._securityTokenAddress);
 
-            const LogAddModule = await I_SecurityToken.allEvents();
+            const LogAddModule = await I_SecurityToken_ETH.allEvents();
             const log = await new Promise(function(resolve, reject) {
                 LogAddModule.watch(function(error, log){ resolve(log);});
             });
 
             // Verify that GeneralTransferManager module get added successfully or not
             assert.equal(log.args._type.toNumber(), transferManagerKey);
-            assert.equal(
-                web3.utils.toAscii(log.args._name)
-                .replace(/\u0000/g, ''),
-                "GeneralTransferManager"
-            );
+            assert.equal(web3.utils.hexToString(log.args._name),"GeneralTransferManager");
             LogAddModule.stopWatching();
         });
 
         it("Should intialize the auto attached modules", async () => {
-           let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
+           let moduleData = await I_SecurityToken_ETH.modules(transferManagerKey, 0);
            I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
 
            assert.notEqual(
@@ -278,15 +286,15 @@ contract('CappedSTO', accounts => {
 
         });
 
-        it("Should fail to launch the STO due to security token doesn't have the sufficeint POLY", async () => {
-            startTime = latestTime() + duration.days(1);           // Start time will be 5000 seconds more than the latest time
-            endTime = startTime + duration.days(30);
+        it("Should fail to launch the STO due to security token doesn't have the sufficient POLY", async () => {
+            let startTime = latestTime() + duration.days(1);
+            let endTime = startTime + duration.days(30);
             await I_PolyToken.getTokens(cappedSTOSetupCost, token_owner);
 
             let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime, endTime, cap, 0, fundRaiseType, account_fundsReceiver]);
             let errorThrown = false;
             try {
-            const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
             } catch(error) {
                 console.log(`         tx revert -> Rate is ${0}. Test Passed Successfully`.grey);
                 errorThrown = true;
@@ -296,12 +304,14 @@ contract('CappedSTO', accounts => {
         });
 
         it("Should fail to launch the STO due to rate is 0", async () => {
-            await I_PolyToken.transfer(I_SecurityToken.address, cappedSTOSetupCost, { from: token_owner});
+            let startTime = latestTime() + duration.days(1);
+            let endTime = startTime + duration.days(30);
+            await I_PolyToken.transfer(I_SecurityToken_ETH.address, cappedSTOSetupCost, { from: token_owner});
 
             let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime, endTime, cap, 0, fundRaiseType, account_fundsReceiver]);
             let errorThrown = false;
             try {
-            const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
             } catch(error) {
                 console.log(`Tx Failed because of rate is ${0}. Test Passed Successfully`);
                 errorThrown = true;
@@ -314,7 +324,7 @@ contract('CappedSTO', accounts => {
             let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [ Math.floor(Date.now()/1000 + 100000), Math.floor(Date.now()/1000 + 1000), cap, rate, fundRaiseType, account_fundsReceiver]);
             let errorThrown = false;
             try {
-            const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
             } catch(error) {
                 errorThrown = true;
                 console.log(`         tx revert -> StartTime is greater than endTime. Test Passed Successfully`.grey);
@@ -324,10 +334,12 @@ contract('CappedSTO', accounts => {
         });
 
         it("Should fail to launch the STO due to cap is of 0 securityToken", async () => {
+            let startTime = latestTime() + duration.days(1);
+            let endTime = startTime + duration.days(30);
             let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [ startTime, endTime, 0, rate, fundRaiseType, account_fundsReceiver]);
             let errorThrown = false;
             try {
-            const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
             } catch(error) {
                 console.log(`Tx Failed because the Cap is equal to ${0}. Test Passed Successfully`);
                 errorThrown = true;
@@ -337,18 +349,15 @@ contract('CappedSTO', accounts => {
         });
 
 
-        it("Should successfully attach the STO factory with the security token", async () => {
-            let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime, endTime, cap, rate, fundRaiseType, account_fundsReceiver]);
-            const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 45000000 });
+        it("Should successfully attach the STO module to the security token", async () => {
+            startTime_ETH1 = latestTime() + duration.days(1);
+            endTime_ETH1 = startTime_ETH1 + duration.days(30);
+            let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime_ETH1, endTime_ETH1, cap, rate, fundRaiseType, account_fundsReceiver]);
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 45000000 });
 
             assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
-            assert.equal(
-                web3.utils.toAscii(tx.logs[3].args._name)
-                .replace(/\u0000/g, ''),
-                "CappedSTO",
-                "CappedSTOFactory module was not added"
-            );
-            I_CappedSTO = CappedSTO.at(tx.logs[3].args._module);
+            assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
+            I_CappedSTO_ETH1 = CappedSTO.at(tx.logs[3].args._module);
         });
     });
 
@@ -356,32 +365,33 @@ contract('CappedSTO', accounts => {
 
         it("Should verify the configuration of the STO", async() => {
             assert.equal(
-                await I_CappedSTO.startTime.call(),
-                startTime,
+                await I_CappedSTO_ETH1.startTime.call(),
+                startTime_ETH1,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO.endTime.call(),
-                endTime,
+                await I_CappedSTO_ETH1.endTime.call(),
+                endTime_ETH1,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                (await I_CappedSTO.cap.call()).toNumber(),
+                (await I_CappedSTO_ETH1.cap.call()).toNumber(),
                 cap,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO.rate.call(),
+                await I_CappedSTO_ETH1.rate.call(),
                 rate,
                 "STO Configuration doesn't set as expected"
             );
             assert.equal(
-                await I_CappedSTO.fundraiseType.call(),
+                await I_CappedSTO_ETH1.fundraiseType.call(),
                 fundRaiseType,
                 "STO Configuration doesn't set as expected"
             );
         });
     });
+
     describe("Buy tokens", async() => {
 
         it("Should buy the tokens -- failed due to startTime is greater than Current time", async () => {
@@ -389,7 +399,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     value: web3.utils.toWei('1', 'ether')
                   });
             } catch(error) {
@@ -405,7 +415,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     value: web3.utils.toWei('0', 'ether')
                   });
             } catch(error) {
@@ -421,7 +431,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     value: web3.utils.toWei('1', 'ether')
                   });
             } catch(error) {
@@ -437,7 +447,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     value: web3.utils.toWei('0.1111', 'ether')
                   });
             } catch(error) {
@@ -470,22 +480,22 @@ contract('CappedSTO', accounts => {
             // Fallback transaction
             await web3.eth.sendTransaction({
                 from: account_investor1,
-                to: I_CappedSTO.address,
+                to: I_CappedSTO_ETH1.address,
                 gas: 2100000,
                 value: web3.utils.toWei('1', 'ether')
               });
 
             assert.equal(
-                (await I_CappedSTO.fundsRaised.call())
+                (await I_CappedSTO_ETH1.fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 1
             );
 
-            assert.equal(await I_CappedSTO.getNumberInvestors.call(), 1);
+            assert.equal(await I_CappedSTO_ETH1.getNumberInvestors.call(), 1);
 
             assert.equal(
-                (await I_SecurityToken.balanceOf(account_investor1))
+                (await I_SecurityToken_ETH.balanceOf(account_investor1))
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 1000
@@ -493,7 +503,7 @@ contract('CappedSTO', accounts => {
         });
 
         it("Verification of the event Token Purchase", async() => {
-            let TokenPurchase = I_CappedSTO.allEvents();
+            let TokenPurchase = I_CappedSTO_ETH1.allEvents();
             let log = await new Promise(function(resolve, reject) {
                 TokenPurchase.watch(function(error, log){ resolve(log);})
             });
@@ -512,7 +522,7 @@ contract('CappedSTO', accounts => {
         it("Should pause the STO -- Failed due to wrong msg.sender", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO.pause({from: account_investor1});
+                let tx = await I_CappedSTO_ETH1.pause({from: account_investor1});
             } catch(error) {
                 console.log(`         tx revert -> Wrong msg.sender`.grey);
                 ensureException(error);
@@ -522,8 +532,8 @@ contract('CappedSTO', accounts => {
         });
 
         it("Should pause the STO", async()=> {
-            let tx = await I_CappedSTO.pause({from: account_issuer});
-            assert.isTrue(await I_CappedSTO.paused.call());
+            let tx = await I_CappedSTO_ETH1.pause({from: account_issuer});
+            assert.isTrue(await I_CappedSTO_ETH1.paused.call());
         });
 
         it("Should fail to buy the tokens after pausing the STO", async() => {
@@ -531,7 +541,7 @@ contract('CappedSTO', accounts => {
             try {
                 await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     gas: 2100000,
                     value: web3.utils.toWei('1', 'ether')
                   });
@@ -546,7 +556,7 @@ contract('CappedSTO', accounts => {
         it("Should unpause the STO -- Failed due to wrong msg.sender", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO.unpause(Math.floor(Date.now()/1000 + 50000), {from: account_investor1});
+                let tx = await I_CappedSTO_ETH1.unpause(Math.floor(Date.now()/1000 + 50000), {from: account_investor1});
             } catch(error) {
                 console.log(`         tx revert -> Wrong msg.sender`.grey);
                 ensureException(error);
@@ -558,7 +568,7 @@ contract('CappedSTO', accounts => {
         it("Should unpause the STO -- Failed due to entered date is less than the end date", async()=> {
             let errorThrown = false;
             try {
-                let tx = await I_CappedSTO.unpause(Math.floor(Date.now()/1000 - 500000), {from: account_issuer});
+                let tx = await I_CappedSTO_ETH1.unpause(Math.floor(Date.now()/1000 - 500000), {from: account_issuer});
             } catch(error) {
                 console.log(`         tx revert -> Entered date is less than the end date`.grey);
                 ensureException(error);
@@ -569,9 +579,9 @@ contract('CappedSTO', accounts => {
 
         it("Should unpause the STO", async()=> {
             await increaseTime(50);
-            let newEndDate = ((await I_CappedSTO.endTime.call()).toNumber() - latestTime()) + latestTime() + 20;
-            let tx = await I_CappedSTO.unpause(newEndDate, {from: account_issuer});
-            assert.isFalse(await I_CappedSTO.paused.call());
+            let newEndDate = ((await I_CappedSTO_ETH1.endTime.call()).toNumber() - latestTime()) + latestTime() + 20;
+            let tx = await I_CappedSTO_ETH1.unpause(newEndDate, {from: account_issuer});
+            assert.isFalse(await I_CappedSTO_ETH1.paused.call());
         });
 
         it("Should buy the tokens -- Failed due to wrong granularity", async () => {
@@ -579,7 +589,7 @@ contract('CappedSTO', accounts => {
             try {
                  await web3.eth.sendTransaction({
                     from: account_investor1,
-                    to: I_CappedSTO.address,
+                    to: I_CappedSTO_ETH1.address,
                     value: web3.utils.toWei('0.1111', 'ether')
                   });
             } catch(error) {
@@ -607,22 +617,22 @@ contract('CappedSTO', accounts => {
              // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO.address,
+                to: I_CappedSTO_ETH1.address,
                 gas: 2100000,
                 value: web3.utils.toWei('9', 'ether')
               });
 
               assert.equal(
-                (await I_CappedSTO.fundsRaised.call())
+                (await I_CappedSTO_ETH1.fundsRaised.call())
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 10
             );
 
-            assert.equal(await I_CappedSTO.getNumberInvestors.call(), 2);
+            assert.equal(await I_CappedSTO_ETH1.getNumberInvestors.call(), 2);
 
             assert.equal(
-                (await I_SecurityToken.balanceOf(account_investor2))
+                (await I_SecurityToken_ETH.balanceOf(account_investor2))
                 .dividedBy(new BigNumber(10).pow(18))
                 .toNumber(),
                 9000
@@ -631,7 +641,7 @@ contract('CappedSTO', accounts => {
                 // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO.address,
+                to: I_CappedSTO_ETH1.address,
                 gas: 210000,
                 value: web3.utils.toWei('1', 'ether')
               });
@@ -648,7 +658,7 @@ contract('CappedSTO', accounts => {
                 // Fallback transaction
              await web3.eth.sendTransaction({
                 from: account_investor2,
-                to: I_CappedSTO.address,
+                to: I_CappedSTO_ETH1.address,
                 gas: 2100000,
                 value: web3.utils.toWei('1', 'ether')
               });
@@ -665,20 +675,104 @@ contract('CappedSTO', accounts => {
             //console.log("WWWW",newBalance,await I_CappedSTO.fundsRaised.call(),balanceOfReceiver);
             let op = (BigNumber(newBalance).minus(balanceOfReceiver)).toNumber();
             assert.equal(
-                (await I_CappedSTO.fundsRaised.call()).toNumber(),
+                (await I_CappedSTO_ETH1.fundsRaised.call()).toNumber(),
                 op,
                 "Somewhere raised money get stolen or sent to wrong wallet"
             );
         });
 
         it("Should get the raised amount of ether", async() => {
-            assert.equal(await I_CappedSTO.getRaisedEther.call(), web3.utils.toWei('10','ether'));
+            assert.equal(await I_CappedSTO_ETH1.getRaisedEther.call(), web3.utils.toWei('10','ether'));
         });
 
         it("Should get the raised amount of poly", async() => {
-            assert.equal((await I_CappedSTO.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('0','ether'));
+            assert.equal((await I_CappedSTO_ETH1.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('0','ether'));
          });
 
+    });
+
+    describe("Attach second ETH STO module", async() => {
+
+        it("Should successfully attach the second STO module to the security token", async () => {
+            startTime_ETH2 = latestTime() + duration.days(1);
+            endTime_ETH2 = startTime_ETH2 + duration.days(30);
+
+            await I_PolyToken.getTokens(cappedSTOSetupCost, token_owner);
+            await I_PolyToken.transfer(I_SecurityToken_ETH.address, cappedSTOSetupCost, { from: token_owner});
+            let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime_ETH2, endTime_ETH2, cap, rate, fundRaiseType, account_fundsReceiver]);
+            const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner });
+
+            assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
+            assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
+            I_CappedSTO_ETH2 = CappedSTO.at(tx.logs[3].args._module);
+        });
+
+        it("Should verify the configuration of the STO", async() => {
+            assert.equal(
+                await I_CappedSTO_ETH2.startTime.call(),
+                startTime_ETH2,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                await I_CappedSTO_ETH2.endTime.call(),
+                endTime_ETH2,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                (await I_CappedSTO_ETH2.cap.call()).toNumber(),
+                cap,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                await I_CappedSTO_ETH2.rate.call(),
+                rate,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                await I_CappedSTO_ETH2.fundraiseType.call(),
+                fundRaiseType,
+                "STO Configuration doesn't set as expected"
+            );
+        });
+
+        it("Should successfully invest in second STO", async() => {
+
+            balanceOfReceiver = await web3.eth.getBalance(account_fundsReceiver);
+
+            let tx = await I_GeneralTransferManager.modifyWhitelist(
+                account_investor3,
+                fromTime,
+                toTime,
+                expiryTime,
+                true,
+                {
+                    from: account_issuer,
+                    gas: 500000
+                });
+
+            assert.equal(tx.logs[0].args._investor, account_investor3, "Failed in adding the investor in whitelist");
+
+            // Jump time to beyond STO start
+            await increaseTime(duration.days(2));
+
+            await I_CappedSTO_ETH2.buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
+
+            assert.equal(
+                (await I_CappedSTO_ETH2.fundsRaised.call())
+                .dividedBy(new BigNumber(10).pow(18))
+                .toNumber(),
+                1
+            );
+
+            assert.equal(await I_CappedSTO_ETH2.getNumberInvestors.call(), 1);
+
+            assert.equal(
+                (await I_SecurityToken_ETH.balanceOf(account_investor3))
+                .dividedBy(new BigNumber(10).pow(18))
+                .toNumber(),
+                1000
+            );
+        });
     });
 
     describe("Test Cases for an STO of fundraise type POLY", async() => {
@@ -693,33 +787,27 @@ contract('CappedSTO', accounts => {
             });
 
             it("POLY: Should generate the new security token with the same symbol as registered above", async () => {
-                P_startTime = endTime + duration.days(2);
-                P_endTime = P_startTime + duration.days(30);
                 await I_PolyToken.approve(I_SecurityTokenRegistry.address, initRegFee, { from: token_owner});
                 let tx = await I_SecurityTokenRegistry.generateSecurityToken(P_name, P_symbol, P_tokenDetails, false, { from: token_owner, gas:85000000 });
 
                 // Verify the successful generation of the security token
                 assert.equal(tx.logs[1].args._ticker, P_symbol, "SecurityToken doesn't get deployed");
 
-                I_SecurityToken = SecurityToken.at(tx.logs[1].args._securityTokenAddress);
+                I_SecurityToken_POLY = SecurityToken.at(tx.logs[1].args._securityTokenAddress);
 
-                const LogAddModule = await I_SecurityToken.allEvents();
+                const LogAddModule = await I_SecurityToken_POLY.allEvents();
                 const log = await new Promise(function(resolve, reject) {
                     LogAddModule.watch(function(error, log){ resolve(log);});
                 });
 
                 // Verify that GeneralTransferManager module get added successfully or not
                 assert.equal(log.args._type.toNumber(), transferManagerKey);
-                assert.equal(
-                    web3.utils.toAscii(log.args._name)
-                    .replace(/\u0000/g, ''),
-                    "GeneralTransferManager"
-                );
+                assert.equal(web3.utils.hexToString(log.args._name),"GeneralTransferManager");
                 LogAddModule.stopWatching();
             });
 
             it("POLY: Should intialize the auto attached modules", async () => {
-                let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
+                let moduleData = await I_SecurityToken_POLY.modules(transferManagerKey, 0);
                 I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
 
                 assert.notEqual(
@@ -730,22 +818,20 @@ contract('CappedSTO', accounts => {
 
              });
 
-             it("POLY: Should successfully attach the STO factory with the security token", async () => {
+             it("POLY: Should successfully attach the STO module to the security token", async () => {
+                startTime_POLY1 = latestTime() + duration.days(2);
+                endTime_POLY1 = startTime_POLY1 + duration.days(30);
+
                 await I_PolyToken.getTokens(cappedSTOSetupCost, token_owner);
-                await I_PolyToken.transfer(I_SecurityToken.address, cappedSTOSetupCost, { from: token_owner});
+                await I_PolyToken.transfer(I_SecurityToken_POLY.address, cappedSTOSetupCost, { from: token_owner});
 
-                let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [P_startTime, P_endTime, P_cap, P_rate, P_fundRaiseType, account_fundsReceiver]);
+                let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime_POLY1, endTime_POLY1, P_cap, P_rate, P_fundRaiseType, account_fundsReceiver]);
 
-                const tx = await I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+                const tx = await I_SecurityToken_POLY.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
 
                 assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
-                assert.equal(
-                    web3.utils.toAscii(tx.logs[3].args._name)
-                    .replace(/\u0000/g, ''),
-                    "CappedSTO",
-                    "CappedSTOFactory module was not added"
-                );
-                I_CappedSTO = CappedSTO.at(tx.logs[3].args._module);
+                assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
+                I_CappedSTO_POLY1 = CappedSTO.at(tx.logs[3].args._module);
             });
 
         });
@@ -754,27 +840,27 @@ contract('CappedSTO', accounts => {
 
             it("Should verify the configuration of the STO", async() => {
                 assert.equal(
-                    (await I_CappedSTO.startTime.call()).toNumber(),
-                    P_startTime,
+                    (await I_CappedSTO_POLY1.startTime.call()).toNumber(),
+                    startTime_POLY1,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    (await I_CappedSTO.endTime.call()).toNumber(),
-                    P_endTime,
+                    (await I_CappedSTO_POLY1.endTime.call()).toNumber(),
+                    endTime_POLY1,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    (await I_CappedSTO.cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
+                    (await I_CappedSTO_POLY1.cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
                     P_cap.dividedBy(new BigNumber(10).pow(18)),
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    await I_CappedSTO.rate.call(),
+                    await I_CappedSTO_POLY1.rate.call(),
                     P_rate,
                     "STO Configuration doesn't set as expected"
                 );
                 assert.equal(
-                    await I_CappedSTO.fundraiseType.call(),
+                    await I_CappedSTO_POLY1.fundraiseType.call(),
                     P_fundRaiseType,
                     "STO Configuration doesn't set as expected"
                 );
@@ -784,8 +870,6 @@ contract('CappedSTO', accounts => {
         describe("Buy tokens", async() => {
 
             it("Should Buy the tokens", async() => {
-                // Add the Investor in to the whitelist
-
                 await I_PolyToken.getTokens((10000 * Math.pow(10, 18)), account_investor1);
 
                 assert.equal(
@@ -812,10 +896,10 @@ contract('CappedSTO', accounts => {
                 // Jump time
                 await increaseTime(duration.days(17));
 
-                await I_PolyToken.approve(I_CappedSTO.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
 
                 // buyTokensWithPoly transaction
-                await I_CappedSTO.buyTokensWithPoly(
+                await I_CappedSTO_POLY1.buyTokensWithPoly(
                     (1000 * Math.pow(10, 18)),
                     {
                         from : account_investor1,
@@ -824,16 +908,16 @@ contract('CappedSTO', accounts => {
                 );
 
                 assert.equal(
-                    (await I_CappedSTO.fundsRaised.call())
+                    (await I_CappedSTO_POLY1.fundsRaised.call())
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     1000
                 );
 
-                assert.equal(await I_CappedSTO.getNumberInvestors.call(), 1);
+                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(), 1);
 
                 assert.equal(
-                    (await I_SecurityToken.balanceOf(account_investor1))
+                    (await I_SecurityToken_POLY.balanceOf(account_investor1))
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     5000
@@ -841,7 +925,7 @@ contract('CappedSTO', accounts => {
             });
 
             it("Verification of the event Token Purchase", async() => {
-                let TokenPurchase = I_CappedSTO.allEvents();
+                let TokenPurchase = I_CappedSTO_POLY1.allEvents();
                 let log = await new Promise(function(resolve, reject) {
                     TokenPurchase.watch(function(error, log){ resolve(log);})
                 });
@@ -873,25 +957,25 @@ contract('CappedSTO', accounts => {
 
                 await I_PolyToken.getTokens((10000 * Math.pow(10, 18)), account_investor2);
 
-                await I_PolyToken.approve(I_CappedSTO.address, (9000 * Math.pow(10, 18)), { from: account_investor2});
+                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (9000 * Math.pow(10, 18)), { from: account_investor2});
 
                 // buyTokensWithPoly transaction
-                await I_CappedSTO.buyTokensWithPoly(
+                await I_CappedSTO_POLY1.buyTokensWithPoly(
                     (9000 * Math.pow(10, 18)),
                     {from : account_investor2, gas: 6000000 }
                 );
 
                   assert.equal(
-                    (await I_CappedSTO.fundsRaised.call())
+                    (await I_CappedSTO_POLY1.fundsRaised.call())
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     10000
                 );
 
-                assert.equal(await I_CappedSTO.getNumberInvestors.call(), 2);
+                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(), 2);
 
                 assert.equal(
-                    (await I_SecurityToken.balanceOf(account_investor2))
+                    (await I_SecurityToken_POLY.balanceOf(account_investor2))
                     .dividedBy(new BigNumber(10).pow(18))
                     .toNumber(),
                     45000
@@ -899,9 +983,9 @@ contract('CappedSTO', accounts => {
                 let errorThrown = false;
                 try {
 
-                await I_PolyToken.approve(I_CappedSTO.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
                 // buyTokensWithPoly transaction
-                await I_CappedSTO.buyTokensWithPoly(
+                await I_CappedSTO_POLY1.buyTokensWithPoly(
                     (1000 * Math.pow(10, 18)),
                     {from : account_investor1, gas: 6000000 }
                 );
@@ -917,9 +1001,9 @@ contract('CappedSTO', accounts => {
                 await increaseTime(duration.days(31)); // increased beyond the end time of the STO
                 let errorThrown = false;
                 try {
-                    await I_PolyToken.approve(I_CappedSTO.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
+                    await I_PolyToken.approve(I_CappedSTO_POLY1.address, (1000 * Math.pow(10, 18)), { from: account_investor1});
                     // buyTokensWithPoly transaction
-                    await I_CappedSTO.buyTokensWithPoly(
+                    await I_CappedSTO_POLY1.buyTokensWithPoly(
                         (1000 * Math.pow(10, 18)),
                         {from : account_investor1, gas: 6000000 }
                     );
@@ -934,7 +1018,7 @@ contract('CappedSTO', accounts => {
             it("Should fundRaised value equal to the raised value in the funds receiver wallet", async() => {
                 const balanceRaised = await I_PolyToken.balanceOf.call(account_fundsReceiver);
                 assert.equal(
-                    (await I_CappedSTO.fundsRaised.call()).toNumber(),
+                    (await I_CappedSTO_POLY1.fundsRaised.call()).toNumber(),
                     balanceRaised,
                     "Somewhere raised money get stolen or sent to wrong wallet"
                 );
@@ -946,8 +1030,7 @@ contract('CappedSTO', accounts => {
             it("should get the exact details of the factory", async() => {
                 assert.equal((await I_CappedSTOFactory.setupCost.call()).toNumber(), cappedSTOSetupCost);
                 assert.equal(await I_CappedSTOFactory.getType.call(),3);
-                assert.equal(web3.utils.toAscii(await I_CappedSTOFactory.getName.call())
-                            .replace(/\u0000/g, ''),
+                assert.equal(web3.utils.hexToString(await I_CappedSTOFactory.getName.call()),
                             "CappedSTO",
                             "Wrong Module added");
                 assert.equal(await I_CappedSTOFactory.getDescription.call(),
@@ -960,39 +1043,133 @@ contract('CappedSTO', accounts => {
                             "Initialises a capped STO. Init parameters are _startTime (time STO starts), _endTime (time STO ends), _cap (cap in tokens for STO), _rate (POLY/ETH to token rate), _fundRaiseType (whether you are raising in POLY or ETH), _polyToken (address of POLY token), _fundsReceiver (address which will receive funds)",
                             "Wrong Module added");
                 let tags = await I_CappedSTOFactory.getTags.call();
-                assert.equal(web3.utils.toAscii(tags[0]).replace(/\u0000/g, ''),"Capped");
+                assert.equal(web3.utils.hexToString(tags[0]),"Capped");
 
             });
          });
 
          describe("Test cases for the get functions of the capped sto", async() => {
              it("Should verify the cap reached or not", async() => {
-                assert.isTrue(await I_CappedSTO.capReached.call());
+                assert.isTrue(await I_CappedSTO_POLY1.capReached.call());
              });
 
              it("Should get the raised amount of ether", async() => {
-                assert.equal(await I_CappedSTO.getRaisedEther.call(), web3.utils.toWei('0','ether'));
+                assert.equal(await I_CappedSTO_POLY1.getRaisedEther.call(), web3.utils.toWei('0','ether'));
              });
 
              it("Should get the raised amount of poly", async() => {
-                assert.equal((await I_CappedSTO.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('10000','ether'));
+                assert.equal((await I_CappedSTO_POLY1.getRaisedPOLY.call()).toNumber(), web3.utils.toWei('10000','ether'));
              });
 
              it("Should get the investors", async() => {
-                assert.equal(await I_CappedSTO.getNumberInvestors.call(),2);
+                assert.equal(await I_CappedSTO_POLY1.getNumberInvestors.call(),2);
              });
 
              it("Should get the listed permissions", async() => {
-                let tx = await I_CappedSTO.getPermissions.call();
+                let tx = await I_CappedSTO_POLY1.getPermissions.call();
                 assert.equal(tx.length,0);
              });
 
              it("Should get the metrics of the STO", async() => {
-                let metrics = await I_CappedSTO.getSTODetails.call();
+                let metrics = await I_CappedSTO_POLY1.getSTODetails.call();
                 assert.isTrue(metrics[7]);
              });
 
          });
     });
 
+    describe("Attach second POLY STO module", async() => {
+        it("Should successfully attach a second STO to the security token", async () => {
+            startTime_POLY2 = latestTime() + duration.days(1);
+            endTime_POLY2 = startTime_POLY2 + duration.days(30);
+
+            await I_PolyToken.getTokens(cappedSTOSetupCost, token_owner);
+            await I_PolyToken.transfer(I_SecurityToken_POLY.address, cappedSTOSetupCost, { from: token_owner});
+
+            let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime_POLY2, endTime_POLY2, P_cap, P_rate, P_fundRaiseType, account_fundsReceiver]);
+
+            const tx = await I_SecurityToken_POLY.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner, gas: 26000000 });
+
+            assert.equal(tx.logs[3].args._type, stoKey, "CappedSTO doesn't get deployed");
+            assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO","CappedSTOFactory module was not added");
+            I_CappedSTO_POLY2 = CappedSTO.at(tx.logs[3].args._module);
+        });
+
+        it("Should verify the configuration of the STO", async() => {
+            assert.equal(
+                (await I_CappedSTO_POLY2.startTime.call()).toNumber(),
+                startTime_POLY2,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                (await I_CappedSTO_POLY2.endTime.call()).toNumber(),
+                endTime_POLY2,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                (await I_CappedSTO_POLY2.cap.call()).dividedBy(new BigNumber(10).pow(18)).toNumber(),
+                P_cap.dividedBy(new BigNumber(10).pow(18)),
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                await I_CappedSTO_POLY2.rate.call(),
+                P_rate,
+                "STO Configuration doesn't set as expected"
+            );
+            assert.equal(
+                await I_CappedSTO_POLY2.fundraiseType.call(),
+                P_fundRaiseType,
+                "STO Configuration doesn't set as expected"
+            );
+        });
+
+        it("Should successfully invest in second STO", async() => {
+
+            const polyToInvest = 1000;
+            const stToReceive = polyToInvest * P_rate;
+
+            await I_PolyToken.getTokens((polyToInvest * Math.pow(10, 18)), account_investor3);
+
+            let tx = await I_GeneralTransferManager.modifyWhitelist(
+                account_investor3,
+                P_fromTime,
+                P_toTime,
+                P_expiryTime,
+                true,
+                {
+                    from: account_issuer,
+                    gas: 500000
+                });
+
+            // Jump time to beyond STO start
+            await increaseTime(duration.days(2));
+
+            await I_PolyToken.approve(I_CappedSTO_POLY2.address, (polyToInvest * Math.pow(10, 18)), { from: account_investor3 });
+
+            // buyTokensWithPoly transaction
+            await I_CappedSTO_POLY2.buyTokensWithPoly(
+                (polyToInvest * Math.pow(10, 18)),
+                {
+                    from : account_investor3,
+                    gas: 6000000
+                }
+            );
+
+            assert.equal(
+                (await I_CappedSTO_POLY2.fundsRaised.call())
+                .dividedBy(new BigNumber(10).pow(18))
+                .toNumber(),
+                polyToInvest
+            );
+
+            assert.equal(await I_CappedSTO_POLY2.getNumberInvestors.call(), 1);
+
+            assert.equal(
+                (await I_SecurityToken_POLY.balanceOf(account_investor3))
+                .dividedBy(new BigNumber(10).pow(18))
+                .toNumber(),
+                stToReceive
+            );
+        });
+    });
 });

--- a/test/capped_sto.js
+++ b/test/capped_sto.js
@@ -776,6 +776,7 @@ contract('CappedSTO', accounts => {
     describe("Test cases for reaching limit number of STO modules", async() => {
 
         it("Should successfully attach STO modules up to the limit and fail at the limit", async () => {
+            const MAX_MODULES = await I_SecurityToken_ETH.MAX_MODULES.call({ from: token_owner });
             let startTime = latestTime() + duration.days(1);
             let endTime = startTime + duration.days(30);
 
@@ -783,7 +784,7 @@ contract('CappedSTO', accounts => {
             await I_PolyToken.transfer(I_SecurityToken_ETH.address, cappedSTOSetupCost*19, { from: token_owner});
             let bytesSTO = web3.eth.abi.encodeFunctionCall(functionSignature, [startTime, endTime, cap, rate, fundRaiseType, account_fundsReceiver]);
 
-            for (var STOIndex = 2; STOIndex < 20; STOIndex++) {
+            for (var STOIndex = 2; STOIndex < MAX_MODULES; STOIndex++) {
                 const tx = await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner });
                 assert.equal(tx.logs[3].args._type, stoKey, `Wrong module type added at index ${STOIndex}`);
                 assert.equal(web3.utils.hexToString(tx.logs[3].args._name),"CappedSTO",`Wrong STO module added at index ${STOIndex}`);
@@ -802,8 +803,9 @@ contract('CappedSTO', accounts => {
         });
 
         it("Should successfully invest in all STO modules attached", async () => {
+            const MAX_MODULES = await I_SecurityToken_ETH.MAX_MODULES.call({ from: token_owner });
             await increaseTime(duration.days(2));
-            for (var STOIndex = 2; STOIndex < 20; STOIndex++) {
+            for (var STOIndex = 2; STOIndex < MAX_MODULES; STOIndex++) {
                 await I_CappedSTO_Array_ETH[STOIndex].buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
                 assert.equal(
                     (await I_CappedSTO_Array_ETH[STOIndex].fundsRaised.call())

--- a/test/concurrent_STO.js
+++ b/test/concurrent_STO.js
@@ -314,6 +314,7 @@ contract('SecurityToken addModule Cap', accounts => {
     describe("Add STO and verify transfer", async() => {
 
         it("Should attach STO modules up to the max number, then fail", async() => {
+            const MAX_MODULES = await I_SecurityToken.MAX_MODULES.call({ from: account_issuer });
             const startTime = latestTime() + duration.days(1);
             const endTime = latestTime() + duration.days(90);
             const cap = new BigNumber(10000).times(new BigNumber(10).pow(18));
@@ -325,7 +326,7 @@ contract('SecurityToken addModule Cap', accounts => {
             const dummyBytesSig = web3.eth.abi.encodeFunctionCall(dummyFuncSig, [startTime, endTime, cap, 'Hello']);
             const presaleBytesSig = web3.eth.abi.encodeFunctionCall(presaleFuncSig, [endTime]);
 
-            for (var STOIndex = 0; STOIndex < 20; STOIndex++) {
+            for (var STOIndex = 0; STOIndex < MAX_MODULES; STOIndex++) {
                 await I_PolyToken.getTokens(STOSetupCost, account_issuer);
                 await I_PolyToken.transfer(I_SecurityToken.address, STOSetupCost, { from: account_issuer });
                 switch (STOIndex % 3) {
@@ -365,9 +366,9 @@ contract('SecurityToken addModule Cap', accounts => {
         });
 
         it("Should successfully invest in all modules attached", async() => {
+            const MAX_MODULES = await I_SecurityToken.MAX_MODULES.call({ from: account_issuer });
             await increaseTime(duration.days(2));
-
-            for (var STOIndex = 0; STOIndex < 20; STOIndex++) {
+            for (var STOIndex = 0; STOIndex < MAX_MODULES; STOIndex++) {
                 switch (STOIndex % 3) {
                     case 0:
                         // Capped STO ETH

--- a/test/concurrent_STO.js
+++ b/test/concurrent_STO.js
@@ -1,0 +1,406 @@
+import latestTime from './helpers/latestTime';
+import { duration, ensureException } from './helpers/utils';
+import { takeSnapshot, increaseTime, revertToSnapshot } from './helpers/time';
+
+// Import contract ABIs
+const CappedSTOFactory = artifacts.require('./CappedSTOFactory.sol');
+const CappedSTO = artifacts.require('./CappedSTO.sol');
+const DummySTOFactory = artifacts.require('./DummySTOFactory.sol');
+const DummySTO = artifacts.require('./DummySTO.sol');
+const PreSaleSTOFactory = artifacts.require('./PreSaleSTOFactory.sol');
+const PreSaleSTO = artifacts.require('./PreSaleSTO.sol');
+
+const ModuleRegistry = artifacts.require('./ModuleRegistry.sol');
+const SecurityToken = artifacts.require('./SecurityToken.sol');
+const SecurityTokenRegistry = artifacts.require('./SecurityTokenRegistry.sol');
+const TickerRegistry = artifacts.require('./TickerRegistry.sol');
+const STVersion = artifacts.require('./STVersionProxy001.sol');
+const GeneralPermissionManagerFactory = artifacts.require('./GeneralPermissionManagerFactory.sol');
+const GeneralTransferManagerFactory = artifacts.require('./GeneralTransferManagerFactory.sol');
+const GeneralTransferManager = artifacts.require('./GeneralTransferManager');
+const GeneralPermissionManager = artifacts.require('./GeneralPermissionManager');
+const PolyTokenFaucet = artifacts.require('./PolyTokenFaucet.sol');
+
+const Web3 = require('web3');
+const BigNumber = require('bignumber.js');
+const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545")) // Hardcoded development port
+
+contract('SecurityToken addModule Cap', accounts => {
+    // Accounts variable declaration
+    let account_polymath;
+    let account_issuer;
+    let account_fundsReceiver;
+    let account_investor1;
+    let account_investor2;
+    let account_investor3;
+
+    // Contract instance declaration
+    let I_GeneralPermissionManagerFactory;
+    let I_GeneralPermissionManager;
+    let I_GeneralTransferManagerFactory;
+    let I_GeneralTransferManager;
+    let I_ModuleRegistry;
+    let I_TickerRegistry;
+    let I_STVersion;
+    let I_SecurityTokenRegistry;
+    let I_SecurityToken;
+    let I_PolyToken;
+
+    // STO instance declaration
+    let I_CappedSTOFactory;
+    let I_DummySTOFactory;
+    let I_PreSaleSTOFactory;
+    let I_STO_Array = [];
+
+    // Error message
+    let message = "Transaction Should Fail!";
+
+    // Initial fees
+    const initRegFee = 25 * Math.pow(10, 18);
+    const STOSetupCost = 200 * Math.pow(10, 18);
+
+    // Module keys
+    const transferManagerKey = 2;
+    const stoKey = 3;
+
+    // Configure function signature for STO deployment
+
+    const cappedFuncSig = {
+        name: 'configure',
+        type: 'function',
+        inputs: [{
+            type: 'uint256',
+            name: '_startTime'
+        },{
+            type: 'uint256',
+            name: '_endTime'
+        },{
+            type: 'uint256',
+            name: '_cap'
+        },{
+            type: 'uint256',
+            name: '_rate'
+        },{
+            type: 'uint8',
+            name: '_fundRaiseType',
+        },{
+            type: 'address',
+            name: '_fundsReceiver'
+        }]
+    };
+
+    const dummyFuncSig = {
+        name: 'configure',
+        type: 'function',
+        inputs: [{
+            type: 'uint256',
+            name: '_startTime'
+        },{
+            type: 'uint256',
+            name: '_endTime'
+        },{
+            type: 'uint256',
+            name: '_cap'
+        },{
+            type: 'string',
+            name: '_someString'
+        }]
+    }
+
+    const presaleFuncSig = {
+        name: 'configure',
+        type: 'function',
+        inputs: [{
+            type: 'uint256',
+            name: '_endTime'
+        }]
+    }
+
+    before(async() => {
+        // Accounts setup
+        account_polymath = accounts[0];
+        account_issuer = accounts[1];
+        account_fundsReceiver = accounts[2];
+        account_investor1 = accounts[3];
+        account_investor2 = accounts[4];
+        account_investor3 = accounts[5]
+
+        // ----------- POLYMATH NETWORK Configuration ------------
+
+        // Step 0: Deploy the token Faucet and Mint tokens for account_issuer
+
+        I_PolyToken = await PolyTokenFaucet.new();
+
+        // STEP 1: Deploy the ModuleRegistry
+
+        I_ModuleRegistry = await ModuleRegistry.new({from:account_polymath});
+
+        assert.notEqual(
+            I_ModuleRegistry.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "ModuleRegistry contract was not deployed"
+        );
+
+        // STEP 2: Deploy the GeneralTransferManagerFactory
+
+        I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(I_PolyToken.address, 0, 0, 0, {from:account_polymath});
+
+        assert.notEqual(
+            I_GeneralTransferManagerFactory.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "GeneralTransferManagerFactory contract was not deployed"
+        );
+
+        // STEP 3: Deploy the GeneralPermissionManagerFactory
+
+        I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(I_PolyToken.address, 0, 0, 0, {from:account_polymath});
+
+        assert.notEqual(
+            I_GeneralPermissionManagerFactory.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "GeneralDelegateManagerFactory contract was not deployed"
+        );
+
+        // STEP 4: Deploy the STO Factories
+
+        I_CappedSTOFactory = await CappedSTOFactory.new(I_PolyToken.address, STOSetupCost, 0, 0, { from: account_issuer });
+        I_DummySTOFactory = await DummySTOFactory.new(I_PolyToken.address, STOSetupCost, 0, 0, { from: account_issuer });
+        I_PreSaleSTOFactory = await PreSaleSTOFactory.new(I_PolyToken.address, STOSetupCost, 0, 0, { from: account_issuer });
+
+        assert.notEqual(
+            I_CappedSTOFactory.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "CappedSTOFactory contract was not deployed"
+        );
+
+        // STEP 5: Register the Modules with the ModuleRegistry contract
+
+        // (A) :  Register the GeneralTransferManagerFactory
+        await I_ModuleRegistry.registerModule(I_GeneralTransferManagerFactory.address, { from: account_polymath });
+        await I_ModuleRegistry.verifyModule(I_GeneralTransferManagerFactory.address, true, { from: account_polymath });
+
+        // (B) :  Register the GeneralDelegateManagerFactory
+        await I_ModuleRegistry.registerModule(I_GeneralPermissionManagerFactory.address, { from: account_polymath });
+        await I_ModuleRegistry.verifyModule(I_GeneralPermissionManagerFactory.address, true, { from: account_polymath });
+
+        // (C) : Register the STO Factories
+        await I_ModuleRegistry.registerModule(I_CappedSTOFactory.address, { from: account_issuer });
+        await I_ModuleRegistry.registerModule(I_DummySTOFactory.address, { from: account_issuer });
+        await I_ModuleRegistry.registerModule(I_PreSaleSTOFactory.address, { from: account_issuer });
+
+        // Step 6: Deploy the TickerRegistry
+
+        I_TickerRegistry = await TickerRegistry.new(I_PolyToken.address, initRegFee, { from: account_polymath });
+
+        assert.notEqual(
+            I_TickerRegistry.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "TickerRegistry contract was not deployed",
+        );
+
+        // Step 7: Deploy the STversionProxy contract
+
+        I_STVersion = await STVersion.new(I_GeneralTransferManagerFactory.address, {from : account_polymath });
+
+        assert.notEqual(
+            I_STVersion.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "STVersion contract was not deployed",
+        );
+
+        // Step 8: Deploy the SecurityTokenRegistry
+
+        I_SecurityTokenRegistry = await SecurityTokenRegistry.new(
+            I_PolyToken.address,
+            I_ModuleRegistry.address,
+            I_TickerRegistry.address,
+            I_STVersion.address,
+            initRegFee,
+            {
+                from: account_polymath
+            });
+
+        assert.notEqual(
+            I_SecurityTokenRegistry.address.valueOf(),
+            "0x0000000000000000000000000000000000000000",
+            "SecurityTokenRegistry contract was not deployed",
+        );
+
+        // Step 8: Set the STR in TickerRegistry
+        await I_TickerRegistry.changeAddress("SecurityTokenRegistry", I_SecurityTokenRegistry.address, {from: account_polymath});
+        await I_ModuleRegistry.changeAddress("SecurityTokenRegistry", I_SecurityTokenRegistry.address, {from: account_polymath});
+
+        // Printing all the contract addresses
+        console.log(`\n
+    ------ Polymath Network Smart Contracts Deployed: ------
+    ModuleRegistry: ${I_ModuleRegistry.address}
+    GeneralTransferManagerFactory: ${I_GeneralTransferManagerFactory.address}
+    GeneralPermissionManagerFactory: ${I_GeneralPermissionManagerFactory.address}
+    CappedSTOFactory: ${I_CappedSTOFactory.address}
+    TickerRegistry: ${I_TickerRegistry.address}
+    STVersionProxy_001: ${I_STVersion.address}
+    SecurityTokenRegistry: ${I_SecurityTokenRegistry.address}
+    --------------------------------------------------------
+        `);
+    });
+
+    describe("Generate Security Token", async() => {
+        // SecurityToken Details for funds raise Type ETH
+        const swarmHash = "dagwrgwgvwergwrvwrg";
+        const name = "Team";
+        const symbol = "SAP";
+        const tokenDetails = "This is equity type of issuance";
+        const decimals = 18;
+
+        it("Should register the ticker before the generation of the security token", async () => {
+            await I_PolyToken.getTokens(initRegFee, account_issuer);
+            await I_PolyToken.approve(I_TickerRegistry.address, initRegFee, { from: account_issuer });
+            let tx = await I_TickerRegistry.registerTicker(account_issuer, symbol, name, swarmHash, { from : account_issuer });
+            assert.equal(tx.logs[0].args._owner, account_issuer);
+            assert.equal(tx.logs[0].args._symbol, symbol);
+        });
+
+        it("Should generate the new security token with the same symbol as registered above", async () => {
+            await I_PolyToken.getTokens(initRegFee, account_issuer);
+            await I_PolyToken.approve(I_SecurityTokenRegistry.address, initRegFee, { from: account_issuer});
+            let tx = await I_SecurityTokenRegistry.generateSecurityToken(name, symbol, tokenDetails, false, { from: account_issuer, gas: 85000000  });
+            assert.equal(tx.logs[1].args._ticker, symbol, "SecurityToken doesn't get deployed");
+
+            I_SecurityToken = SecurityToken.at(tx.logs[1].args._securityTokenAddress);
+
+            const LogAddModule = await I_SecurityToken.allEvents();
+            const log = await new Promise(function(resolve, reject) {
+                LogAddModule.watch(function(error, log){ resolve(log);});
+            });
+
+            // Verify that GeneralTransferManager module get added successfully or not
+            assert.equal(log.args._type.toNumber(), transferManagerKey);
+            assert.equal(web3.utils.hexToString(log.args._name),"GeneralTransferManager");
+            LogAddModule.stopWatching();
+        });
+
+        it("Should intialize the auto attached modules", async () => {
+            let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
+            I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
+
+            assert.notEqual(
+                I_GeneralTransferManager.address.valueOf(),
+                "0x0000000000000000000000000000000000000000",
+                "GeneralTransferManager contract was not deployed",
+            );
+        });
+
+        it("Should whitelist account_investor1", async() => {
+            let fromTime = latestTime();
+            let toTime = latestTime() + duration.days(15);
+            let expiryTime = toTime + duration.days(100);
+            let canBuyFromSTO = true;
+
+            let tx = await I_GeneralTransferManager.modifyWhitelist(
+                account_investor1,
+                fromTime,
+                toTime,
+                expiryTime,
+                canBuyFromSTO,
+                {
+                    from: account_issuer,
+                    gas: 500000
+                });
+
+            assert.equal(tx.logs[0].args._investor, account_investor1, "Failed in adding the investor in whitelist");
+        });
+    });
+
+    describe("Add STO and verify transfer", async() => {
+
+        it("Should attach STO modules up to the max number, then fail", async() => {
+            const startTime = latestTime() + duration.days(1);
+            const endTime = latestTime() + duration.days(90);
+            const cap = new BigNumber(10000).times(new BigNumber(10).pow(18));
+            const rate = 1000;
+            const fundRaiseType = 0;
+            const budget = 0;
+            const maxCost = STOSetupCost;
+            const cappedBytesSig = web3.eth.abi.encodeFunctionCall(cappedFuncSig, [startTime, endTime, cap, rate, fundRaiseType, account_fundsReceiver]);
+            const dummyBytesSig = web3.eth.abi.encodeFunctionCall(dummyFuncSig, [startTime, endTime, cap, 'Hello']);
+            const presaleBytesSig = web3.eth.abi.encodeFunctionCall(presaleFuncSig, [endTime]);
+
+            for (var STOIndex = 0; STOIndex < 20; STOIndex++) {
+                await I_PolyToken.getTokens(STOSetupCost, account_issuer);
+                await I_PolyToken.transfer(I_SecurityToken.address, STOSetupCost, { from: account_issuer });
+                switch (STOIndex % 3) {
+                    case 0:
+                        // Capped STO
+                        let tx1 = await I_SecurityToken.addModule(I_CappedSTOFactory.address, cappedBytesSig, maxCost, budget, { from: account_issuer });
+                        assert.equal(tx1.logs[3].args._type, stoKey, `Wrong module type added at index ${STOIndex}`);
+                        assert.equal(web3.utils.hexToString(tx1.logs[3].args._name),"CappedSTO",`Wrong STO module added at index ${STOIndex}`);
+                        I_STO_Array.push(CappedSTO.at(tx1.logs[3].args._module));
+                        break;
+                    case 1:
+                        // Dummy STO
+                        let tx2 = await I_SecurityToken.addModule(I_DummySTOFactory.address, dummyBytesSig, maxCost, budget, { from: account_issuer });
+                        assert.equal(tx2.logs[3].args._type, stoKey, `Wrong module type added at index ${STOIndex}`);
+                        assert.equal(web3.utils.hexToString(tx2.logs[3].args._name),"DummySTO",`Wrong STO module added at index ${STOIndex}`);
+                        I_STO_Array.push(DummySTO.at(tx2.logs[3].args._module));
+                        break;
+                    case 2:
+                        // Pre Sale STO
+                        let tx3 = await I_SecurityToken.addModule(I_PreSaleSTOFactory.address, presaleBytesSig, maxCost, budget, { from: account_issuer });
+                        assert.equal(tx3.logs[3].args._type, stoKey, `Wrong module type added at index ${STOIndex}`);
+                        assert.equal(web3.utils.hexToString(tx3.logs[3].args._name),"PreSaleSTO",`Wrong STO module added at index ${STOIndex}`);
+                        I_STO_Array.push(PreSaleSTO.at(tx3.logs[3].args._module));
+                        break;
+                }
+            }
+
+            let errorThrown = false;
+            try {
+                await I_SecurityToken.addModule(I_CappedSTOFactory.address, cappedBytesSig, maxCost, budget, { from: account_issuer });
+            } catch(error) {
+                console.log(`         tx revert -> reached cap number of modules attached`.grey);
+                ensureException(error);
+                errorThrown = true;
+            }
+            assert.ok(errorThrown, message);
+        });
+
+        it("Should successfully invest in all modules attached", async() => {
+            await increaseTime(duration.days(2));
+
+            for (var STOIndex = 0; STOIndex < 20; STOIndex++) {
+                switch (STOIndex % 3) {
+                    case 0:
+                        // Capped STO ETH
+                        await I_STO_Array[STOIndex].buyTokens(account_investor1, { from : account_investor1, value: web3.utils.toWei('1', 'ether') });
+                        assert.equal(web3.utils.fromWei((await I_STO_Array[STOIndex].fundsRaised.call()).toString()), 1);
+                        assert.equal(await I_STO_Array[STOIndex].getNumberInvestors.call(), 1);
+                        break;
+                    case 1:
+                        // Dummy STO
+                        await I_STO_Array[STOIndex].generateTokens(account_investor1, web3.utils.toWei('1000'), { from : account_issuer });
+                        assert.equal(await I_STO_Array[STOIndex].getNumberInvestors.call(), 1);
+                        assert.equal(
+                            (await I_STO_Array[STOIndex].investors.call(account_investor1))
+                            .dividedBy(new BigNumber(10).pow(18))
+                            .toNumber(),
+                            1000
+                        );
+                        break;
+                    case 2:
+                        // Pre Sale STO
+                        await I_STO_Array[STOIndex].allocateTokens(account_investor1, web3.utils.toWei('1000'), web3.utils.toWei('1'), 0, { from : account_issuer });
+                        assert.equal(web3.utils.fromWei((await I_STO_Array[STOIndex].getRaisedEther.call()).toString()), 1);
+                        assert.equal(web3.utils.fromWei((await I_STO_Array[STOIndex].getRaisedPOLY.call()).toString()), 0);
+                        assert.equal(await I_STO_Array[STOIndex].getNumberInvestors.call(), 1);
+                        assert.equal(
+                            (await I_STO_Array[STOIndex].investors.call(account_investor1))
+                            .dividedBy(new BigNumber(10).pow(18))
+                            .toNumber(),
+                            1000
+                        );
+                        break;
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
In capped_sto I cleaned up some global variables to prevent overwriting which was causing the new tests to fail.
I made concurrent_sto to test adding and investing in multiple different types of STOs. It can easily be extended to cover new STO modules.