### PR TITLE
 Prevent upgrade from impacting ability to attach modules

### DIFF
--- a/contracts/ModuleRegistry.sol
+++ b/contracts/ModuleRegistry.sol
@@ -40,6 +40,7 @@ contract ModuleRegistry is IModuleRegistry, Pausable, RegistryUpdater, ReclaimTo
    /**
     * @notice Called by a security token to notify the registry it is using a module
     * @param _moduleFactory is the address of the relevant module factory
+    * @param _securityTokenRegistry is the address of the Security Token Registry
     */
     function useModule(address _moduleFactory, address _securityTokenRegistry) external {
         //If caller is a registered security token, then register module usage

--- a/contracts/ModuleRegistry.sol
+++ b/contracts/ModuleRegistry.sol
@@ -41,9 +41,9 @@ contract ModuleRegistry is IModuleRegistry, Pausable, RegistryUpdater, ReclaimTo
     * @notice Called by a security token to notify the registry it is using a module
     * @param _moduleFactory is the address of the relevant module factory
     */
-    function useModule(address _moduleFactory) external {
+    function useModule(address _moduleFactory, address _securityTokenRegistry) external {
         //If caller is a registered security token, then register module usage
-        if (ISecurityTokenRegistry(securityTokenRegistry).isSecurityToken(msg.sender)) {
+        if (ISecurityTokenRegistry(_securityTokenRegistry).isSecurityToken(msg.sender)) {
             require(registry[_moduleFactory] != 0, "ModuleFactory type should not be 0");
             //To use a module, either it must be verified, or owned by the ST owner
             require(verified[_moduleFactory]||(IModuleFactory(_moduleFactory).owner() == ISecurityToken(msg.sender).owner()),

--- a/contracts/interfaces/IModuleRegistry.sol
+++ b/contracts/interfaces/IModuleRegistry.sol
@@ -9,7 +9,7 @@ contract IModuleRegistry {
      * @notice Called by a security token to notify the registry it is using a module
      * @param _moduleFactory is the address of the relevant module factory
      */
-    function useModule(address _moduleFactory) external;
+    function useModule(address _moduleFactory, address _securityTokenRegistry) external {
 
     /**
      * @notice Called by moduleFactory owner to register new modules for SecurityToken to use

--- a/contracts/interfaces/IModuleRegistry.sol
+++ b/contracts/interfaces/IModuleRegistry.sol
@@ -9,7 +9,7 @@ contract IModuleRegistry {
      * @notice Called by a security token to notify the registry it is using a module
      * @param _moduleFactory is the address of the relevant module factory
      */
-    function useModule(address _moduleFactory, address _securityTokenRegistry) external {
+    function useModule(address _moduleFactory, address _securityTokenRegistry) external;
 
     /**
      * @notice Called by moduleFactory owner to register new modules for SecurityToken to use

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -183,7 +183,7 @@ contract SecurityToken is ISecurityToken, ReentrancyGuard, RegistryUpdater {
     */
     function _addModule(address _moduleFactory, bytes _data, uint256 _maxCost, uint256 _budget) internal {
         //Check that module exists in registry - will throw otherwise
-        IModuleRegistry(moduleRegistry).useModule(_moduleFactory);
+        IModuleRegistry(moduleRegistry).useModule(_moduleFactory, securityTokenRegistry);
         IModuleFactory moduleFactory = IModuleFactory(_moduleFactory);
         uint8 moduleType = moduleFactory.getType();
         require(modules[moduleType].length < MAX_MODULES, "Limit of MAX MODULES is reached");


### PR DESCRIPTION
By passing the address of the STR from the security token, we are allowing the issuer to continue attaching existing registered modules despite registry upgrade.