### PR TITLE
Remove max modules

### DIFF
--- a/contracts/interfaces/ISecurityToken.sol
+++ b/contracts/interfaces/ISecurityToken.sol
@@ -55,7 +55,7 @@ interface ISecurityToken {
      * @return uint256 name index
 
      */
-    function getModule(address _module) external view;
+    function getModule(address _module) external view returns(bytes32, address, address, bool, uint8, uint256, uint256);
 
     /**
      * @notice returns module list for a module name

--- a/contracts/interfaces/ISecurityToken.sol
+++ b/contracts/interfaces/ISecurityToken.sol
@@ -44,27 +44,32 @@ interface ISecurityToken {
     function checkPermission(address _delegate, address _module, bytes32 _perm) external view returns (bool);
 
     /**
+     * @notice Returns module list for a module type
+     * @param _module address of the module
+     * @return bytes32 name
+     * @return address module address
+     * @return address module factory address
+     * @return bool module archived
+     * @return uint8 module type
+     * @return uint256 module index
+     * @return uint256 name index
+
+     */
+    function getModule(address _module) external view;
+
+    /**
+     * @notice returns module list for a module name
+     * @param _name name of the module
+     * @return address[] list of modules with this name
+     */
+    function getModulesByName(bytes32 _name) external view returns (address[]);
+
+    /**
      * @notice returns module list for a module type
-     * @param _moduleType is which type of module we are trying to access
-     * @param _moduleIndex is the index of the module within the chosen type
+     * @param _type type of the module
+     * @return address[] list of modules with this type
      */
-    function getModule(uint8 _moduleType, uint _moduleIndex) external view returns (bytes32, address);
-
-    /**
-     * @notice returns a module that matches the provided name - will return first match
-     * @param _moduleType is which type of module we are trying to access
-     * @param _name is the name of the module within the chosen type
-     */
-    function getModuleByName(uint8 _moduleType, bytes32 _name) external view returns (bytes32, address);
-
-    /**
-     * @notice returns all the modules that match the provided name within a module type
-     * @param _moduleType is the type of module we are trying to get
-     * @param _name is the name of the module within the chosen type
-     * @return bytes32
-     * @return address
-     */
-    function getAllModulesByName(uint8 _moduleType, bytes32 _name) external view returns (bytes32[], address[]);
+    function getModulesByType(uint8 _type) external view returns (address[]);
 
     /**
      * @notice Queries totalSupply at a specified checkpoint
@@ -119,11 +124,10 @@ interface ISecurityToken {
 
     /**
     * @notice allows owner to approve more POLY to one of the modules
-    * @param _moduleType is the selected module type
-    * @param _moduleIndex is the index of the module in the selected type list
-    * @param _budget is the new budget for the selected module
+    * @param _module module address
+    * @param _budget new budget
     */
-    function changeModuleBudget(uint8 _moduleType, uint8 _moduleIndex, uint256 _budget) external;
+    function changeModuleBudget(address _module, uint256 _budget) external;
 
     /**
      * @notice changes the tokenDetails
@@ -177,10 +181,21 @@ interface ISecurityToken {
 
     /**
     * @notice Removes a module attached to the SecurityToken
-    * @param _moduleType is which type of module we are trying to remove
-    * @param _moduleIndex is the index of the module within the chosen type
+    * @param _module address of module to archive
     */
-    function removeModule(uint8 _moduleType, uint8 _moduleIndex) external;
+    function removeModule(address _module) external;
+
+    /**
+    * @notice Archives a module attached to the SecurityToken
+    * @param _module address of module to archive
+    */
+    function archiveModule(address _module) external;
+
+    /**
+    * @notice Unarchives a module attached to the SecurityToken
+    * @param _module address of module to unarchive
+    */
+    function unarchiveModule(address _module) external;
 
     /**
      * @notice Function used to attach the module in security token

--- a/contracts/modules/TransferManager/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManager.sol
@@ -283,11 +283,8 @@ contract GeneralTransferManager is ITransferManager {
      * @notice Internal function use to know whether the STO is attached or not
      */
     function _isSTOAttached() internal view returns(bool) {
-        address _sto;
-        (, _sto) = ISecurityToken(securityToken).getModule(3, 0);
-        if (_sto == address(0))
-            return false;
-        return true;
+        bool attached = ISecurityToken(securityToken).getModulesByType(3).length > 0;
+        return attached;
     }
 
 }

--- a/contracts/modules/TransferManager/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManager.sol
@@ -161,7 +161,7 @@ contract GeneralTransferManager is ITransferManager {
                 return Result.VALID;
             }
             if (allowAllWhitelistTransfers) {
-                //Anyone on the whitelist can transfer, regardless of block number
+                //Anyone on the whitelist can transfer, regardless of time
                 return (_onWhitelist(_to) && _onWhitelist(_from)) ? Result.VALID : Result.NA;
             }
             if (allowAllWhitelistIssuances && _from == issuanceAddress) {

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -296,15 +296,20 @@ contract SecurityToken is StandardToken, DetailedERC20, ReentrancyGuard, Registr
         uint256 length = modules[moduleType].length;
         modules[moduleType][index] = modules[moduleType][length - 1];
         modules[moduleType].length = length - 1;
+        if ((length - 1) != index) {
+            modulesToData[modules[moduleType][index]].moduleIndex = index;
+        }
         // Remove from module names list
         index = modulesToData[_module].nameIndex;
         bytes32 name = modulesToData[_module].name;
         length = names[name].length;
         names[name][index] = names[name][length - 1];
         names[name].length = length - 1;
+        if ((length - 1) != index) {
+            modulesToData[modules[moduleType][index]].nameIndex = index;
+        }
         // Remove from modulesToData
         delete modulesToData[_module];
-
     }
 
     /**

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -135,11 +135,12 @@ contract SecurityToken is StandardToken, DetailedERC20, ReentrancyGuard, Registr
     modifier onlyModuleOrOwner(uint8 _type) {
         if (msg.sender == owner) {
             _;
+        } else {
+          require(modulesToData[msg.sender].module == msg.sender, "Address mismatch");
+          require(modulesToData[msg.sender].moduleType == _type, "Type mismatch");
+          require(!modulesToData[msg.sender].isArchived, "Module archived");
+          _;
         }
-        require(modulesToData[msg.sender].module == msg.sender, "Address mismatch");
-        require(modulesToData[msg.sender].moduleType == _type, "Type mismatch");
-        require(!modulesToData[msg.sender].isArchived, "Module archived");
-        _;
     }
 
     modifier checkGranularity(uint256 _amount) {
@@ -186,6 +187,7 @@ contract SecurityToken is StandardToken, DetailedERC20, ReentrancyGuard, Registr
         transferFunctions[bytes4(keccak256("transferFrom(address,address,uint256)"))] = true;
         transferFunctions[bytes4(keccak256("mint(address,uint256)"))] = true;
         transferFunctions[bytes4(keccak256("burn(uint256)"))] = true;
+        transferFunctions[bytes4(keccak256("mintMulti(address[],uint256[])"))] = true;
     }
 
     /**

--- a/test/b_capped_sto.js
+++ b/test/b_capped_sto.js
@@ -304,14 +304,7 @@ contract('CappedSTO', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken_ETH.modules(transferManagerKey, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
-
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
         });
 
         it("Should mint the tokens before attaching the STO", async() => {
@@ -865,8 +858,8 @@ contract('CappedSTO', accounts => {
 
     describe("Test cases for reaching limit number of STO modules", async() => {
 
-        it("Should successfully attach STO modules up to the limit and fail at the limit", async () => {
-            const MAX_MODULES = await I_SecurityToken_ETH.MAX_MODULES.call({ from: token_owner });
+        it("Should successfully attach 10 STO modules", async () => {
+            const MAX_MODULES = 10;
             let startTime = latestTime() + duration.days(1);
             let endTime = startTime + duration.days(30);
 
@@ -881,19 +874,10 @@ contract('CappedSTO', accounts => {
                 I_CappedSTO_Array_ETH.push(CappedSTO.at(tx.logs[3].args._module));
             }
 
-            let errorThrown = false;
-            try {
-                 await I_SecurityToken_ETH.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, 0, { from: token_owner });
-            } catch(error) {
-                console.log(`         tx revert -> reached cap number of modules attached`.grey);
-                ensureException(error);
-                errorThrown = true;
-            }
-            assert.ok(errorThrown, message);
         });
 
         it("Should successfully invest in all STO modules attached", async () => {
-            const MAX_MODULES = await I_SecurityToken_ETH.MAX_MODULES.call({ from: token_owner });
+            const MAX_MODULES = 10;
             await increaseTime(duration.days(2));
             for (var STOIndex = 2; STOIndex < MAX_MODULES; STOIndex++) {
                 await I_CappedSTO_Array_ETH[STOIndex].buyTokens(account_investor3, { from : account_investor3, value: web3.utils.toWei('1', 'ether') });
@@ -938,14 +922,7 @@ contract('CappedSTO', accounts => {
 
             it("POLY: Should intialize the auto attached modules", async () => {
                 let moduleData = await I_SecurityToken_POLY.modules(transferManagerKey, 0);
-                I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-                assert.notEqual(
-                 I_GeneralTransferManager.address.valueOf(),
-                 "0x0000000000000000000000000000000000000000",
-                 "GeneralTransferManager contract was not deployed",
-                );
-
+                I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
              });
 
              it("POLY: Should successfully attach the STO module to the security token", async () => {

--- a/test/c_checkpoints.js
+++ b/test/c_checkpoints.js
@@ -232,14 +232,7 @@ contract('Checkpoints', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
-
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
         });
 
     });

--- a/test/d_count_transfer_manager.js
+++ b/test/d_count_transfer_manager.js
@@ -279,13 +279,7 @@ contract('CountTransferManager', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 

--- a/test/e_erc20_dividends.js
+++ b/test/e_erc20_dividends.js
@@ -270,13 +270,7 @@ contract('ERC20DividendCheckpoint', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 

--- a/test/f_ether_dividends.js
+++ b/test/f_ether_dividends.js
@@ -271,13 +271,7 @@ contract('EtherDividendCheckpoint', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 

--- a/test/g_general_permission_manager.js
+++ b/test/g_general_permission_manager.js
@@ -301,14 +301,7 @@ contract('GeneralPermissionManager', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
-
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
         });
 
         it("Should successfully attach the General permission manager factory with the security token", async () => {

--- a/test/h_general_transfer_manager.js
+++ b/test/h_general_transfer_manager.js
@@ -289,13 +289,7 @@ contract('GeneralTransferManager', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 
@@ -628,7 +622,7 @@ contract('GeneralTransferManager', accounts => {
         });
 
         it("Should set a budget for the GeneralTransferManager", async() => {
-            await I_SecurityToken.changeModuleBudget(2, 0, 10 * Math.pow(10, 18), {from: token_owner});
+            await I_SecurityToken.changeModuleBudget(I_GeneralTransferManager.address, 10 * Math.pow(10, 18), {from: token_owner});
             let errorThrown = false;
             try {
                 await I_GeneralTransferManager.takeFee(web3.utils.toWei('1','ether'), {from: account_polymath});

--- a/test/i_Issuance.js
+++ b/test/i_Issuance.js
@@ -294,13 +294,8 @@ contract('Issuance', accounts => {
 
             it("POLYMATH: Should intialize the auto attached modules", async () => {
                 let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
-                I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
+                I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
-                assert.notEqual(
-                 I_GeneralTransferManager.address.valueOf(),
-                 "0x0000000000000000000000000000000000000000",
-                 "GeneralTransferManager contract was not deployed",
-                );
 
              });
 
@@ -360,7 +355,7 @@ contract('Issuance', accounts => {
                  //First attach a permission manager to the token
                  await I_SecurityToken.addModule(I_GeneralPermissionManagerFactory.address, "", 0, 0, {from: account_polymath});
                  let moduleData = await I_SecurityToken.modules(permissionManagerKey, 0);
-                 I_GeneralPermissionManager = GeneralPermissionManager.at(moduleData[1]);
+                 I_GeneralPermissionManager = GeneralPermissionManager.at(moduleData);
                  // Add permission to the deletgate (A regesteration process)
                  await I_GeneralPermissionManager.addPermission(account_delegate, delegateDetails, { from: account_polymath});
                  // Providing the permission to the delegate

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -283,13 +283,7 @@ contract('ManualApprovalTransferManager', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 

--- a/test/k_module_registry.js
+++ b/test/k_module_registry.js
@@ -519,15 +519,8 @@ contract('ModuleRegistry', accounts => {
         });
 
         it("Should intialize the auto attached modules", async () => {
-        let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
-        I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-            assert.notEqual(
-                I_GeneralTransferManager.address.valueOf(),
-                "0x0000000000000000000000000000000000000000",
-                "GeneralTransferManager contract was not deployed",
-            );
-
+            let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
+            I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
         });
 
     });

--- a/test/l_percentage_transfer_manager.js
+++ b/test/l_percentage_transfer_manager.js
@@ -280,13 +280,7 @@ contract('PercentageTransferManager', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(2, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
         });
 

--- a/test/m_presale_sto.js
+++ b/test/m_presale_sto.js
@@ -269,14 +269,7 @@ contract('PreSaleSTO', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
-
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
         });
 
         it("Should fail to launch the STO due to endTime is 0", async () => {

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -501,13 +501,7 @@ contract('SecurityTokenRegistry', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
             let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
-            I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
-
-            assert.notEqual(
-             I_GeneralTransferManager.address.valueOf(),
-             "0x0000000000000000000000000000000000000000",
-             "GeneralTransferManager contract was not deployed",
-            );
+            I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
          });
 

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -588,27 +588,33 @@ contract('SecurityToken', accounts => {
 
     describe("Module related functions", async() => {
         it("Should get the modules of the securityToken by index", async () => {
-            let moduleData = await I_SecurityToken.getModule.call(stoKey, 0);
+            let moduleData = await I_SecurityToken.getModule.call(I_CappedSTO.address);
             assert.equal(web3.utils.toAscii(moduleData[0]).replace(/\u0000/g, ''), "CappedSTO");
             assert.equal(moduleData[1], I_CappedSTO.address);
+            assert.equal(moduleData[2], I_CappedSTOFactory.address);
+            assert.equal(moduleData[3], false);
+            assert.equal(moduleData[4], 3);
+            assert.equal(moduleData[5], 0);
+            assert.equal(moduleData[6], 0);
         });
 
         it("Should get the modules of the securityToken by index (not added into the security token yet)", async () => {
-            let moduleData = await I_SecurityToken.getModule.call(permissionManagerKey, 0);
+            let moduleData = await I_SecurityToken.getModule.call(token_owner);
             assert.equal(web3.utils.toAscii(moduleData[0]).replace(/\u0000/g, ''), "");
             assert.equal(moduleData[1], "0x0000000000000000000000000000000000000000");
         });
 
         it("Should get the modules of the securityToken by name", async () => {
-            let moduleData = await I_SecurityToken.getAllModulesByName.call(stoKey, "CappedSTO");
+            let moduleList = await I_SecurityToken.getModulesByName.call("CappedSTO");
+            assert.equal(moduleList.length == 1, "Only one STO");
+            let moduleData = await I_SecurityToken.getModule.call(moduleList[0]);
             assert.equal(web3.utils.toAscii(moduleData[0][0]).replace(/\u0000/g, ''), "CappedSTO");
             assert.equal(moduleData[1][0], I_CappedSTO.address);
         });
 
         it("Should get the modules of the securityToken by name (not added into the security token yet)", async () => {
-            let moduleData = await I_SecurityToken.getAllModulesByName.call(permissionManagerKey, "GeneralPermissionManager");
-            assert.equal(moduleData[0].length, 0);
-            assert.equal(moduleData[1].length, 0);
+            let moduleData = await I_SecurityToken.getModulesByName.call("GeneralPermissionManager");
+            assert.equal(moduleList.length == 0, "No Permission Manager");
         });
 
         it("Should get the modules of the securityToken by name (not added into the security token yet)", async () => {

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -654,6 +654,18 @@ contract('SecurityToken', accounts => {
             assert.ok(errorThrown, message);
         });
 
+        it("Should fail to remove the module - module not archived", async() => {
+            let errorThrown = false;
+            try {
+                let tx = await I_SecurityToken.removeModule(I_GeneralTransferManager.address, { from : token_owner });
+            } catch (error) {
+                console.log(`       tx -> Failed because address doesn't exist`);
+                errorThrown = true;
+                ensureException(error);
+            }
+            assert.ok(errorThrown, message);
+        })
+
         it("Should fail to remove the module - incorrect address", async() => {
             let errorThrown = false;
             try {
@@ -668,6 +680,7 @@ contract('SecurityToken', accounts => {
 
         it("Should successfully remove the general transfer manager module from the securityToken", async() => {
             let key = await takeSnapshot();
+            await I_SecurityToken.archiveModule(I_GeneralTransferManager.address, { from : token_owner });
             let tx = await I_SecurityToken.removeModule(I_GeneralTransferManager.address, { from : token_owner });
             assert.equal(tx.logs[0].args._type, transferManagerKey);
             assert.equal(tx.logs[0].args._module, I_GeneralTransferManager.address);

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -690,9 +690,11 @@ contract('SecurityToken', accounts => {
         });
 
         it("Should successfully mint tokens while GTM archived", async () => {
+            let key = await takeSnapshot();
             await I_SecurityToken.mint(1, (100 * Math.pow(10, 18)), {from: token_owner, gas: 500000});
-            let balance = await I_SecurityToken.balanceOf(address(1));
-            assert.equal(balance.dividedBy(new BigNumber(10).pow(18)).toNumber(), 300);
+            let balance = await I_SecurityToken.balanceOf(1);
+            assert.equal(balance.dividedBy(new BigNumber(10).pow(18)).toNumber(), 100);
+            await revertToSnapshot(key);
         });
 
         it("Should successfully unarchive the general transfer manager module from the securityToken", async() => {
@@ -1202,10 +1204,11 @@ contract('SecurityToken', accounts => {
            it("Should check that the list of investors is correct", async ()=> {
                // Hardcode list of expected accounts based on transfers above
                let investorsLength = await I_SecurityToken.getInvestorsLength();
+               console.log(JSON.stringify(investorsLength));
                let expectedAccounts = [account_affiliate1, account_affiliate2, account_investor1, account_temp];
-               assert.equal(investorsLength, 4);
-               console.log("Total Seen Investors: " + investorsLength);
-               for (let i = 0; i < investorsLength; i++) {
+               assert.equal(investorsLength.toNumber(), 4);
+               console.log("Total Seen Investors: " + investorsLength.toNumber());
+               for (let i = 0; i < investorsLength.toNumber(); i++) {
                  let investor = await I_SecurityToken.investors(i);
                  assert.equal(investor, expectedAccounts[i]);
                }

--- a/test/q_usd_tiered_sto.js
+++ b/test/q_usd_tiered_sto.js
@@ -359,13 +359,8 @@ contract('USDTieredSTO', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(TMKEY, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
         });
     });
 

--- a/test/r_usd_tiered_sto_sim.js
+++ b/test/r_usd_tiered_sto_sim.js
@@ -335,13 +335,8 @@ contract('USDTieredSTO', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
            let moduleData = await I_SecurityToken.modules(TMKEY, 0);
-           I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
+           I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
-           assert.notEqual(
-            I_GeneralTransferManager.address.valueOf(),
-            "0x0000000000000000000000000000000000000000",
-            "GeneralTransferManager contract was not deployed",
-           );
         });
 
         it("Should successfully attach the first STO module to the security token", async () => {

--- a/test/s_concurrent_STO.js
+++ b/test/s_concurrent_STO.js
@@ -303,13 +303,8 @@ contract('SecurityToken addModule Cap', accounts => {
 
         it("Should intialize the auto attached modules", async () => {
             let moduleData = await I_SecurityToken.modules(transferManagerKey, 0);
-            I_GeneralTransferManager = GeneralTransferManager.at(moduleData[1]);
+            I_GeneralTransferManager = GeneralTransferManager.at(moduleData);
 
-            assert.notEqual(
-                I_GeneralTransferManager.address.valueOf(),
-                "0x0000000000000000000000000000000000000000",
-                "GeneralTransferManager contract was not deployed",
-            );
         });
 
         it("Should whitelist account_investor1", async() => {
@@ -336,7 +331,7 @@ contract('SecurityToken addModule Cap', accounts => {
     describe("Add STO and verify transfer", async() => {
 
         it("Should attach STO modules up to the max number, then fail", async() => {
-            const MAX_MODULES = await I_SecurityToken.MAX_MODULES.call({ from: account_issuer });
+            const MAX_MODULES = 10;
             const startTime = latestTime() + duration.days(1);
             const endTime = latestTime() + duration.days(90);
             const cap = new BigNumber(10000).times(new BigNumber(10).pow(18));
@@ -376,19 +371,10 @@ contract('SecurityToken addModule Cap', accounts => {
                 }
             }
 
-            let errorThrown = false;
-            try {
-                await I_SecurityToken.addModule(I_CappedSTOFactory.address, cappedBytesSig, maxCost, budget, { from: account_issuer });
-            } catch(error) {
-                console.log(`         tx revert -> reached cap number of modules attached`.grey);
-                ensureException(error);
-                errorThrown = true;
-            }
-            assert.ok(errorThrown, message);
         });
 
         it("Should successfully invest in all modules attached", async() => {
-            const MAX_MODULES = await I_SecurityToken.MAX_MODULES.call({ from: account_issuer });
+            const MAX_MODULES = 10;
             await increaseTime(duration.days(2));
             for (var STOIndex = 0; STOIndex < MAX_MODULES; STOIndex++) {
                 switch (STOIndex % 3) {


### PR DESCRIPTION
Fix #260 

@VictorVicente to make corresponding CLI changes

Uses an internal function for verifyTransfer rather than signature matching on `msg.data`

Removes MAX_MODULES and changes the `onlyModule` modifier to be constant time.

Modules can be:
archived: makes a module not valid for the purposes of `onlyModule`. Can be unarchived
unarchived: reverts archive
remove: permanently remove module (can't be re-added)

NB: We still have a dependency on the number of TM modules attached as we loop over these in `verifyTransfer`.