### PR TITLE
Add additional transfer / mint / burn functions with _data parameter

### DIFF
--- a/contracts/modules/Burn/TrackedRedemption.sol
+++ b/contracts/modules/Burn/TrackedRedemption.sol
@@ -37,7 +37,7 @@ contract TrackedRedemption is IBurn, Module {
      * @param _value The number of tokens to redeem
      */
     function redeemTokens(uint256 _value) public {
-        ISecurityToken(securityToken).burnFrom(msg.sender, _value);
+        ISecurityToken(securityToken).burnFromWithData(msg.sender, _value, "");
         redeemedTokens[msg.sender] = redeemedTokens[msg.sender].add(_value);
         emit Redeemed(msg.sender, _value, now);
     }

--- a/contracts/modules/TransferManager/CountTransferManager.sol
+++ b/contracts/modules/TransferManager/CountTransferManager.sol
@@ -26,7 +26,7 @@ contract CountTransferManager is ITransferManager {
     }
 
     /// @notice Used to verify the transfer transaction according to the rule implemented in the trnasfer managers
-    function verifyTransfer(address /* _from */, address _to, uint256 /* _amount */, bool /* _isTransfer */) public returns(Result) {
+    function verifyTransfer(address /* _from */, address _to, uint256 /* _amount */, bytes /* _data */, bool /* _isTransfer */) public returns(Result) {
         if (!paused) {
             if (maxHolderCount < ISecurityToken(securityToken).getInvestorCount()) {
                 // Allow transfers to existing maxHolders

--- a/contracts/modules/TransferManager/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManager.sol
@@ -151,7 +151,7 @@ contract GeneralTransferManager is ITransferManager {
     * b) Seller's sale lockup period is over
     * c) Buyer's purchase lockup is over
     */
-    function verifyTransfer(address _from, address _to, uint256 /*_amount*/, bool /* _isTransfer */) public returns(Result) {
+    function verifyTransfer(address _from, address _to, uint256 /*_amount*/, bytes /* _data */, bool /* _isTransfer */) public returns(Result) {
         if (!paused) {
             if (allowAllTransfers) {
                 //All transfers allowed, regardless of whitelist

--- a/contracts/modules/TransferManager/ITransferManager.sol
+++ b/contracts/modules/TransferManager/ITransferManager.sol
@@ -16,7 +16,7 @@ contract ITransferManager is Module, Pausable {
     //  NA, then the result from this TM is ignored
     enum Result {INVALID, NA, VALID, FORCE_VALID}
 
-    function verifyTransfer(address _from, address _to, uint256 _amount, bool _isTransfer) public returns(Result);
+    function verifyTransfer(address _from, address _to, uint256 _amount, bytes _data, bool _isTransfer) public returns(Result);
 
     function unpause() onlyOwner public {
         super._unpause();

--- a/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
@@ -87,7 +87,7 @@ contract ManualApprovalTransferManager is ITransferManager {
     * b) Seller's sale lockup period is over
     * c) Buyer's purchase lockup is over
     */
-    function verifyTransfer(address _from, address _to, uint256 _amount, bool _isTransfer) public returns(Result) {
+    function verifyTransfer(address _from, address _to, uint256 _amount, bytes /* _data */, bool _isTransfer) public returns(Result) {
         // function must only be called by the associated security token if _isTransfer == true
         require(_isTransfer == false || msg.sender == securityToken, "Sender is not owner");
         // manual blocking takes precidence over manual approval

--- a/contracts/modules/TransferManager/PercentageTransferManager.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManager.sol
@@ -38,7 +38,7 @@ contract PercentageTransferManager is ITransferManager {
     }
 
     /// @notice Used to verify the transfer transaction according to the rule implemented in the trnasfer managers
-    function verifyTransfer(address /* _from */, address _to, uint256 _amount, bool /* _isTransfer */) public returns(Result) {
+    function verifyTransfer(address /* _from */, address _to, uint256 _amount, bytes /* _data */, bool /* _isTransfer */) public returns(Result) {
         if (!paused) {
             // If an address is on the whitelist, it is allowed to hold more than maxHolderPercentage of the tokens.
             if (whitelist[_to]) {

--- a/test/c_checkpoints.js
+++ b/test/c_checkpoints.js
@@ -389,7 +389,7 @@ contract('Checkpoints', accounts => {
                     }
                     n = n.toFixed(0);
                     console.log("Burning: " + n.toString() + " from: " + burner);
-                    await I_SecurityToken.forceBurn(burner, n, "", { from: token_owner });
+                    await I_SecurityToken.forceBurn(burner, n, "", "", { from: token_owner });
                 }
                 console.log("Checking Interim...");
                 for (let k = 0; k < cps.length; k++) {

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -371,7 +371,7 @@ contract('ManualApprovalTransferManager', accounts => {
         it("Cannot call verifyTransfer on the TM directly if _isTransfer == true", async() => {
             let errorThrown = false;
             try {
-                await I_ManualApprovalTransferManager.verifyTransfer(account_investor4, account_investor4, web3.utils.toWei('2', 'ether'), true, { from: token_owner });
+                await I_ManualApprovalTransferManager.verifyTransfer(account_investor4, account_investor4, web3.utils.toWei('2', 'ether'), "", true, { from: token_owner });
             } catch(error) {
                 console.log(`         tx revert -> invalid not from SecurityToken`.grey);
                 ensureException(error);
@@ -382,7 +382,7 @@ contract('ManualApprovalTransferManager', accounts => {
         });
 
         it("Can call verifyTransfer on the TM directly if _isTransfer == false", async() => {
-            await I_ManualApprovalTransferManager.verifyTransfer(account_investor4, account_investor4, web3.utils.toWei('2', 'ether'), false, { from: token_owner });
+            await I_ManualApprovalTransferManager.verifyTransfer(account_investor4, account_investor4, web3.utils.toWei('2', 'ether'), "", false, { from: token_owner });
         });
 
         it("Add a new token holder", async() => {
@@ -503,14 +503,14 @@ contract('ManualApprovalTransferManager', accounts => {
         });
 
         it("Check verifyTransfer without actually transferring", async() => {
-            let verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('1', 'ether'));
+            let verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('1', 'ether'), "");
             console.log(JSON.stringify(verified));
             assert.equal(verified, true);
 
-            verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('2', 'ether'));
+            verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('2', 'ether'), "");
             assert.equal(verified, false);
 
-            verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('1', 'ether'));
+            verified = await I_SecurityToken.verifyTransfer.call(account_investor1, account_investor4, web3.utils.toWei('1', 'ether'), "");
             assert.equal(verified, true);
 
         });

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -1157,7 +1157,7 @@ contract('SecurityToken', accounts => {
               let currentInvestorCount = await I_SecurityToken.getInvestorCount.call();
               let currentBalance = await I_SecurityToken.balanceOf(account_temp);
               try {
-                  let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance + web3.utils.toWei("500", "ether"), "", { from: account_controller });
+                  let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance + web3.utils.toWei("500", "ether"), "", "", { from: account_controller });
               } catch(error) {
                   console.log(`         tx revert -> value is greater than its current balance`.grey);
                   errorThrown = true;
@@ -1171,7 +1171,7 @@ contract('SecurityToken', accounts => {
                let currentInvestorCount = await I_SecurityToken.getInvestorCount.call();
                let currentBalance = await I_SecurityToken.balanceOf(account_temp);
                try {
-                   let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance, "", { from: token_owner });
+                   let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance, "", "", { from: token_owner });
                } catch(error) {
                    console.log(`         tx revert -> not owner`.grey);
                    errorThrown = true;
@@ -1184,7 +1184,7 @@ contract('SecurityToken', accounts => {
                 let currentInvestorCount = await I_SecurityToken.getInvestorCount.call();
                 let currentBalance = await I_SecurityToken.balanceOf(account_temp);
                 // console.log(currentInvestorCount.toString(), currentBalance.toString());
-                let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance, "", { from: account_controller });
+                let tx = await I_SecurityToken.forceBurn(account_temp, currentBalance, "", "", { from: account_controller });
                 // console.log(tx.logs[0].args._value.toNumber(), currentBalance.toNumber());
                 assert.equal(tx.logs[0].args._value.toNumber(), currentBalance.toNumber());
                 let newInvestorCount = await I_SecurityToken.getInvestorCount.call();
@@ -1261,7 +1261,7 @@ contract('SecurityToken', accounts => {
             it("Should fail to forceTransfer because not approved controller", async() => {
                 let errorThrown1 = false;
                 try {
-                    await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "reason", {from: account_investor1});
+                    await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "", "reason", {from: account_investor1});
                 } catch (error) {
                     console.log(`         tx revert -> not approved controller`.grey);
                     errorThrown1 = true;
@@ -1273,7 +1273,7 @@ contract('SecurityToken', accounts => {
             it("Should fail to forceTransfer because insufficient balance", async() => {
                 let errorThrown = false;
                 try {
-                    await I_SecurityToken.forceTransfer(account_investor2, account_investor1, web3.utils.toWei("10", "ether"), "reason", {from: account_controller});
+                    await I_SecurityToken.forceTransfer(account_investor2, account_investor1, web3.utils.toWei("10", "ether"), "", "reason", {from: account_controller});
                 } catch (error) {
                     console.log(`         tx revert -> insufficient balance`.grey);
                     errorThrown = true;
@@ -1285,7 +1285,7 @@ contract('SecurityToken', accounts => {
             it("Should fail to forceTransfer because recipient is zero address", async() => {
                 let errorThrown = false;
                 try {
-                    await I_SecurityToken.forceTransfer(account_investor1, address_zero, web3.utils.toWei("10", "ether"), "reason", {from: account_controller});
+                    await I_SecurityToken.forceTransfer(account_investor1, address_zero, web3.utils.toWei("10", "ether"), "", "reason", {from: account_controller});
                 } catch (error) {
                     console.log(`         tx revert -> recipient is zero address`.grey);
                     errorThrown = true;
@@ -1302,7 +1302,7 @@ contract('SecurityToken', accounts => {
                 let start_balInv1 = await I_SecurityToken.balanceOf.call(account_investor1);
                 let start_balInv2 = await I_SecurityToken.balanceOf.call(account_investor2);
 
-                let tx = await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "reason", {from: account_controller});
+                let tx = await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "", "reason", {from: account_controller});
 
                 let end_investorCount = await I_SecurityToken.getInvestorCount.call();
                 let end_balInv1 = await I_SecurityToken.balanceOf.call(account_investor1);
@@ -1391,7 +1391,7 @@ contract('SecurityToken', accounts => {
             it("Should fail to forceTransfer because controller functionality frozen", async() => {
                 let errorThrown = false;
                 try {
-                    await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "reason", {from: account_controller});
+                    await I_SecurityToken.forceTransfer(account_investor1, account_investor2, web3.utils.toWei("10", "ether"), "", "reason", {from: account_controller});
                 } catch (error) {
                     console.log(`         tx revert -> recipient is zero address`.grey);
                     errorThrown = true;


### PR DESCRIPTION
This PR adds transfer, mint & burn functions with an additional `bytes _data` parameter which is passed onto TransferManagers.

This would allow us to do off-chain whitelisting - for example if an exchange is generating a dynamic deposit address for a customer they could also provide a signed piece of data which authorises this address (assuming the issuer had added a TM that accepted this signed data).

More or less inspired from ERC 1400 although more ERC20 like in naming.

For the burn functions, I didn't include the non-data versions as these aren't part of the ERC20 specification in any case (probably the same argument could be made for mint, but that is already used in lots of places so I left the old version of the function).