### PR TITLE
Decimals fixed for percentage

### DIFF
--- a/contracts/modules/TransferManager/PercentageTransferManager.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManager.sol
@@ -45,7 +45,7 @@ contract PercentageTransferManager is ITransferManager {
                 return Result.NA;
             }
             uint256 newBalance = ISecurityToken(securityToken).balanceOf(_to).add(_amount);
-            if (newBalance.mul(10**uint256(ISecurityToken(securityToken).decimals())).div(ISecurityToken(securityToken).totalSupply()) > maxHolderPercentage) {
+            if (newBalance.mul(uint256(10)**18).div(ISecurityToken(securityToken).totalSupply()) > maxHolderPercentage) {
                 return Result.INVALID;
             }
             return Result.NA;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our Submission guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
Multiply by a fixed amount for percentage calculation


### What is the current behavior? 
% is calculated assuming token has 18 decimals


### What is the new behavior?
% is calculated using 18 decimals no matter how many decimals the token has


### Does this PR introduce a breaking change?
No


### Any Other information:
We could have either changed the natspec comment to mention that percentage is in (10 ^ (decimals - 2)) or just use fixed (18) decimals for calculation. I went with the latter.