### PR TITLE
Ignored OpenZeppelin in GreenKeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
     "solium": "^1.1.6",
     "truffle": "^4.1.11",
     "truffle-wallet-provider": "0.0.5"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "openzeppelin-solidity"
+    ]
   }
 }


### PR DESCRIPTION
Updated package.json so that greenkeeper ignores OpenZeppelin when updating packages.