### PR TITLE
Multiple controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 [__1.5.0__](https://www.npmjs.com/package/polymath-core?activeTab=readme) __15-08-18__
 
 ## Added
+* Added support for multiple controllers of a security token. `setController` event and function changed, `disableForceTransfer` event and function added.
 * Migrated from `npm` to `yarn`.
 * Added `SingleTradeVolumeRestrictionManager` module
 * Added flag in `PercentageTransferManager` to allow ignoring of issuance transfers

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -184,7 +184,6 @@ contract SecurityToken is StandardToken, DetailedERC20, ReentrancyGuard, Registr
             require(_isModule(msg.sender, _type), "Unauthorized");
             _;
         }
-        _;
     }
 
     /**

--- a/test/c_checkpoints.js
+++ b/test/c_checkpoints.js
@@ -131,7 +131,7 @@ contract("Checkpoints", accounts => {
         });
 
         it("Should set controller to token owner", async () => {
-            await I_SecurityToken.setController(token_owner, { from: token_owner });
+            await I_SecurityToken.setController(token_owner, true, { from: token_owner });
         });
 
         it("Should intialize the auto attached modules", async () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our Submission guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
Added support for multiple controllers


### What is the current behavior? 
Only a single controller/operator is allowed

### What is the new behavior?
Multiple controllers/operators are allowed


### Does this PR introduce a breaking change?
- `controllerDisabled` variable renamed to `forceTransferDisabled`. `DisableController` event renamed to `DisableForceTransfer`. To disable controllers, use `setController` function.
- `controller` variable is now a mapping instead of a single address.
- `createCheckpoint` can now also be called by controllers
- `setController` (function and event) now takes a second variable (boolean) which defines if the controller is being activated or deactivated. (true -> add controller | false -> remove controller)



### Any Other information:
Gas cost for generating ST rose from 7.54m to 7.56m.