### PR TITLE
[Fix] Duplicate Address in exclusions[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,8 @@ All notable changes to this project will be documented in this file.
 * Add new function `modifyTickerDetails()`, To modify the details of undeployed ticker. #230     
 
 ## Fixed
-<<<<<<< HEAD
 * 0x0 and duplicate address in exclusions are no longer allowed in dividend modules.
-=======
 * All permissions are denied if no permission manager is active.
->>>>>>> development-1.5.0
 * Generalize the STO varaible names and added them in `ISTO.sol` to use the common standard in all STOs.
 * Generalize the event when any new token get registered with the polymath ecosystem. `LogNewSecurityToken` should emit _ticker, _name, _securityTokenAddress, _owner, _addedAt, _registrant respectively. #230  
 * Change the function name of `withdraPoly` to `withdrawERC20` and make the function generalize to extract tokens from the ST contract. parmeters are contract address and the value need to extract from the securityToken.          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 * Add new function `modifyTickerDetails()`, To modify the details of undeployed ticker. #230     
 
 ## Fixed
+* 0x0 and duplicate address in exclusions are no longer allowed in dividend modules.
 * Generalize the STO varaible names and added them in `ISTO.sol` to use the common standard in all STOs.
 * Generalize the event when any new token get registered with the polymath ecosystem. `LogNewSecurityToken` should emit _ticker, _name, _securityTokenAddress, _owner, _addedAt, _registrant respectively. #230  
 * Change the function name of `withdraPoly` to `withdrawERC20` and make the function generalize to extract tokens from the ST contract. parmeters are contract address and the value need to extract from the securityToken.          

--- a/contracts/modules/Checkpoint/DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/DividendCheckpoint.sol
@@ -51,10 +51,10 @@ contract DividendCheckpoint is ICheckpoint, Module {
     event SetWithholdingFixed(address[] _investors, uint256 _withholding, uint256 _timestamp);
 
     modifier validDividendIndex(uint256 _dividendIndex) {
-        require(_dividendIndex < dividends.length, "Incorrect dividend index");
-        require(!dividends[_dividendIndex].reclaimed, "Dividend has been reclaimed by issuer");
-        require(now >= dividends[_dividendIndex].maturity, "Dividend maturity is in the future");
-        require(now < dividends[_dividendIndex].expiry, "Dividend expiry is in the past");
+        require(_dividendIndex < dividends.length, "Invalid dividend");
+        require(!dividends[_dividendIndex].reclaimed, "Dividend reclaimed");
+        require(now >= dividends[_dividendIndex].maturity, "Dividend maturity in future");
+        require(now < dividends[_dividendIndex].expiry, "Dividend expiry in past");
         _;
     }
 
@@ -164,7 +164,7 @@ contract DividendCheckpoint is ICheckpoint, Module {
     function pullDividendPayment(uint256 _dividendIndex) public validDividendIndex(_dividendIndex)
     {
         Dividend storage dividend = dividends[_dividendIndex];
-        require(!dividend.claimed[msg.sender], "Dividend already claimed by msg.sender");
+        require(!dividend.claimed[msg.sender], "Dividend already claimed");
         require(!dividend.dividendExcluded[msg.sender], "msg.sender excluded from Dividend");
         _payDividend(msg.sender, dividend, _dividendIndex);
     }
@@ -190,7 +190,7 @@ contract DividendCheckpoint is ICheckpoint, Module {
      * @return claim, withheld amounts
      */
     function calculateDividend(uint256 _dividendIndex, address _payee) public view returns(uint256, uint256) {
-        require(_dividendIndex < dividends.length, "Incorrect dividend index");
+        require(_dividendIndex < dividends.length, "Invalid dividend");
         Dividend storage dividend = dividends[_dividendIndex];
         if (dividend.claimed[_payee] || dividend.dividendExcluded[_payee]) {
             return (0, 0);

--- a/contracts/modules/Checkpoint/DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/DividendCheckpoint.sol
@@ -79,6 +79,12 @@ contract DividendCheckpoint is ICheckpoint, Module {
      */
     function setDefaultExcluded(address[] _excluded) public withPerm(MANAGE) {
         require(_excluded.length <= EXCLUDED_ADDRESS_LIMIT, "Too many excluded addresses");
+        for (uint256 j = 0; j < _excluded.length; j++) {
+            require (_excluded[j] != address(0), "Invalid address");
+            for (uint256 i = j + 1; i < _excluded.length; i++) {
+                require (_excluded[j] != _excluded[i], "Duplicate exclude address");
+            }
+        }
         excluded = _excluded;
         emit SetDefaultExcludedAddresses(excluded, now);
     }

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
@@ -143,12 +143,11 @@ contract ERC20DividendCheckpoint is DividendCheckpoint {
 
         for (uint256 j = 0; j < _excluded.length; j++) {
             require (_excluded[j] != address(0), "Invalid address");
-            for (uint256 i = j + 1; i < _excluded.length; i++) {
-                require (_excluded[j] != _excluded[i], "Duplicate exclude address");
-            }
+            require(!dividends[dividendIndex].dividendExcluded[_excluded[j]], "duped exclude address");
             excludedSupply = excludedSupply.add(securityTokenInstance.balanceOfAt(_excluded[j], _checkpointId));
             dividends[dividendIndex].dividendExcluded[_excluded[j]] = true;
         }
+
         dividends[dividendIndex].totalSupply = currentSupply.sub(excludedSupply);
         dividendTokens[dividendIndex] = _token;
         _emitERC20DividendDepositedEvent(_checkpointId, _maturity, _expiry, _token, _amount, currentSupply, dividendIndex, _name);

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
@@ -142,9 +142,15 @@ contract ERC20DividendCheckpoint is DividendCheckpoint {
             _name
           )
         );
+
         for (uint256 j = 0; j < _excluded.length; j++) {
+            require (_excluded[j] != address(0), "Invalid address");
+            for (i = j + 1; i < _excluded.length; i++) {
+                require (_excluded[j] != _excluded[i], "Duplicate exclude address");
+            }
             dividends[dividends.length - 1].dividendExcluded[_excluded[j]] = true;
         }
+
         dividendTokens[dividendIndex] = _token;
         _emitERC20DividendDepositedEvent(_checkpointId, _maturity, _expiry, _token, _amount, currentSupply, dividendIndex, _name);
     }

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -32,7 +32,7 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      */
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
-            require(polyToken.transferFrom(msg.sender, owner, setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+            require(polyToken.transferFrom(msg.sender, owner, setupCost), "insufficent allowance");
         address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender, address(polyToken));
         emit GenerateModuleFromFactory(erc20DividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return erc20DividendCheckpoint;
@@ -86,7 +86,7 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      * @notice Returns the instructions associated with the module
      */
     function getInstructions() external view returns(string) {
-        return "Create a ERC20 dividend which will be paid out to token holders proportional to their balances at the point the dividend is created";
+        return "Create ERC20 dividend to be paid out to token holders based on their balances at dividend creation time";
     }
 
     /**

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -124,9 +124,7 @@ contract EtherDividendCheckpoint is DividendCheckpoint {
 
         for (uint256 j = 0; j < _excluded.length; j++) {
             require (_excluded[j] != address(0), "Invalid address");
-            for (uint256 i = j + 1; i < _excluded.length; i++) {
-                require (_excluded[j] != _excluded[i], "Duplicate exclude address");
-            }
+            require(!dividends[dividendIndex].dividendExcluded[_excluded[j]], "duped exclude address");
             excludedSupply = excludedSupply.add(ISecurityToken(securityToken).balanceOfAt(_excluded[j], _checkpointId));
             dividends[dividendIndex].dividendExcluded[_excluded[j]] = true;
         }

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -124,9 +124,15 @@ contract EtherDividendCheckpoint is DividendCheckpoint {
             _name
           )
         );
+
         for (uint256 j = 0; j < _excluded.length; j++) {
+            require (_excluded[j] != address(0), "Invalid address");
+            for (i = j + 1; i < _excluded.length; i++) {
+                require (_excluded[j] != _excluded[i], "Duplicate exclude address");
+            }
             dividends[dividends.length - 1].dividendExcluded[_excluded[j]] = true;
         }
+
         emit EtherDividendDeposited(msg.sender, _checkpointId, now, _maturity, _expiry, msg.value, currentSupply, dividendIndex, _name);
     }
 

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -126,12 +126,11 @@ contract EtherDividendCheckpoint is DividendCheckpoint {
             require (_excluded[j] != address(0), "Invalid address");
             for (uint256 i = j + 1; i < _excluded.length; i++) {
                 require (_excluded[j] != _excluded[i], "Duplicate exclude address");
-                excludedSupply = excludedSupply.add(ISecurityToken(securityToken).balanceOfAt(_excluded[i], _checkpointId));            
-                dividends[dividends.length - 1].dividendExcluded[_excluded[i]] = true;
             }
-            dividends[dividends.length - 1].dividendExcluded[_excluded[j]] = true;
+            excludedSupply = excludedSupply.add(ISecurityToken(securityToken).balanceOfAt(_excluded[j], _checkpointId));
+            dividends[dividendIndex].dividendExcluded[_excluded[j]] = true;
         }
-        dividends[dividends.length -1].totalSupply = currentSupply.sub(excludedSupply);
+        dividends[dividendIndex].totalSupply = currentSupply.sub(excludedSupply);
         emit EtherDividendDeposited(msg.sender, _checkpointId, now, _maturity, _expiry, msg.value, currentSupply, dividendIndex, _name);
     }
 

--- a/test/e_erc20_dividends.js
+++ b/test/e_erc20_dividends.js
@@ -1119,7 +1119,7 @@ contract("ERC20DividendCheckpoint", accounts => {
                 assert.equal(await I_ERC20DividendCheckpointFactory.getTitle.call(), "ERC20 Dividend Checkpoint", "Wrong Module added");
                 assert.equal(
                     await I_ERC20DividendCheckpointFactory.getInstructions.call(),
-                    "Create a ERC20 dividend which will be paid out to token holders proportional to their balances at the point the dividend is created",
+                    "Create ERC20 dividend to be paid out to token holders based on their balances at dividend creation time",
                     "Wrong Module added"
                 );
                 let tags = await I_ERC20DividendCheckpointFactory.getTags.call();

--- a/test/f_ether_dividends.js
+++ b/test/f_ether_dividends.js
@@ -554,7 +554,8 @@ contract("EtherDividendCheckpoint", accounts => {
             limit = limit.toNumber();
             let addresses = [];
             addresses.push(account_temp);
-            while (limit--) addresses.push(limit);
+            addresses.push(token_owner);
+            while (--limit) addresses.push(limit);
             await catchRevert(
                 I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(maturity, expiry, 4, addresses, dividendName, {
                     from: token_owner,
@@ -577,6 +578,34 @@ contract("EtherDividendCheckpoint", accounts => {
                 { from: token_owner, value: web3.utils.toWei("10", "ether") }
             );
             assert.equal(tx.logs[0].args._checkpointId.toNumber(), 4, "Dividend should be created at checkpoint 4");
+        });
+
+        it("Should not create new dividend with duplicate exclusion", async () => {
+            let maturity = latestTime();
+            let expiry = latestTime() + duration.days(10);
+            //checkpoint created in above test
+            await catchRevert(I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(
+                maturity,
+                expiry,
+                4,
+                [account_investor1, account_investor1],
+                dividendName,
+                { from: token_owner, value: web3.utils.toWei("10", "ether") }
+            ));
+        });
+
+        it("Should not create new dividend with 0x0 address in exclusion", async () => {
+            let maturity = latestTime();
+            let expiry = latestTime() + duration.days(10);
+            //checkpoint created in above test
+            await catchRevert(I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(
+                maturity,
+                expiry,
+                4,
+                [0],
+                dividendName,
+                { from: token_owner, value: web3.utils.toWei("10", "ether") }
+            ));
         });
 
         it("Non-owner pushes investor 1 - fails", async () => {
@@ -807,7 +836,7 @@ contract("EtherDividendCheckpoint", accounts => {
         it("should not allow manager without permission to create dividend with exclusion", async () => {
             let maturity = latestTime() + duration.days(1);
             let expiry = latestTime() + duration.days(10);
-            let exclusions = [0];
+            let exclusions = [1];
             await catchRevert(I_EtherDividendCheckpoint.createDividendWithExclusions(
                 maturity,
                 expiry,
@@ -820,7 +849,7 @@ contract("EtherDividendCheckpoint", accounts => {
         it("should not allow manager without permission to create dividend with checkpoint and exclusion", async () => {
             let maturity = latestTime() + duration.days(1);
             let expiry = latestTime() + duration.days(10);
-            let exclusions = [0];
+            let exclusions = [1];
             let checkpointID = await I_SecurityToken.createCheckpoint.call({ from: token_owner });
             await I_SecurityToken.createCheckpoint({ from: token_owner }); 
             await catchRevert(I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(
@@ -875,7 +904,7 @@ contract("EtherDividendCheckpoint", accounts => {
         it("should allow manager with permission to create dividend with exclusion", async () => {
             let maturity = latestTime() + duration.days(1);
             let expiry = latestTime() + duration.days(10);
-            let exclusions = [0];
+            let exclusions = [1];
             let tx = await I_EtherDividendCheckpoint.createDividendWithExclusions(
                 maturity,
                 expiry,
@@ -889,7 +918,7 @@ contract("EtherDividendCheckpoint", accounts => {
         it("should allow manager with permission to create dividend with checkpoint and exclusion", async () => {
             let maturity = latestTime() + duration.days(1);
             let expiry = latestTime() + duration.days(10);
-            let exclusions = [0];
+            let exclusions = [1];
             let checkpointID = await I_SecurityToken.createCheckpoint.call({ from: token_owner });
             await I_SecurityToken.createCheckpoint({ from: token_owner });
             let tx = await I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our Submission guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
Duplicate and zero address are no longer allowed in exclusions list when creating a dividend with exclusion or setting default exclusions.
