### PR TITLE
getAllModulesAndPermsFromTypes fetch token address from storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 * Add new function `modifyTickerDetails()`, To modify the details of undeployed ticker. #230     
 
 ## Fixed
+* `getAllModulesAndPermsFromTypes()` does not take securityToken address as a parameter anymore.
 * Generalize the STO varaible names and added them in `ISTO.sol` to use the common standard in all STOs.
 * Generalize the event when any new token get registered with the polymath ecosystem. `LogNewSecurityToken` should emit _ticker, _name, _securityTokenAddress, _owner, _addedAt, _registrant respectively. #230  
 * Change the function name of `withdraPoly` to `withdrawERC20` and make the function generalize to extract tokens from the ST contract. parmeters are contract address and the value need to extract from the securityToken.          

--- a/contracts/modules/PermissionManager/GeneralPermissionManager.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManager.sol
@@ -172,16 +172,15 @@ contract GeneralPermissionManager is IPermissionManager, Module {
      * @notice use to return all permission of a single or multiple module
      * @dev possible that function get out of gas is there are lot of modules and perm related to them
      * @param _delegate Ethereum address of the delegate
-     * @param _tokenAddress Ethereum address of the security token
      * @param _types uint8[] of types
      * @return address[] the address array of Modules this delegate has permission
      * @return bytes32[] the permission array of the corresponding Modules
      */
-    function getAllModulesAndPermsFromTypes(address _delegate, uint8[] _types, address _tokenAddress) external view returns(address[], bytes32[]) {
+    function getAllModulesAndPermsFromTypes(address _delegate, uint8[] _types) external view returns(address[], bytes32[]) {
         uint256 counter = 0;
         // loop through _types and get their modules from securityToken->getModulesByType
         for (uint256 i = 0; i < _types.length; i++) {
-            address[] memory _currentTypeModules = ISecurityToken(_tokenAddress).getModulesByType(_types[i]);
+            address[] memory _currentTypeModules = ISecurityToken(securityToken).getModulesByType(_types[i]);
             // loop through each modules to get their perms from IModule->getPermissions
             for (uint256 j = 0; j < _currentTypeModules.length; j++){
                 bytes32[] memory _allModulePerms = IModule(_currentTypeModules[j]).getPermissions();
@@ -199,7 +198,7 @@ contract GeneralPermissionManager is IPermissionManager, Module {
         counter = 0;
 
         for (i = 0; i < _types.length; i++){
-            _currentTypeModules = ISecurityToken(_tokenAddress).getModulesByType(_types[i]);
+            _currentTypeModules = ISecurityToken(securityToken).getModulesByType(_types[i]);
             for (j = 0; j < _currentTypeModules.length; j++) {
                 _allModulePerms = IModule(_currentTypeModules[j]).getPermissions();
                 for (k = 0; k < _allModulePerms.length; k++) {

--- a/contracts/modules/PermissionManager/IPermissionManager.sol
+++ b/contracts/modules/PermissionManager/IPermissionManager.sol
@@ -78,12 +78,11 @@ interface IPermissionManager {
     * @notice use to return all permission of a single or multiple module
     * @dev possible that function get out of gas is there are lot of modules and perm related to them
     * @param _delegate Ethereum address of the delegate
-    * @param _tokenAddress Ethereum address of the security token
     * @param _types uint8[] of types
     * @return address[] the address array of Modules this delegate has permission
     * @return bytes32[] the permission array of the corresponding Modules
     */
-    function getAllModulesAndPermsFromTypes(address _delegate, uint8[] _types, address _tokenAddress) external view returns(address[], bytes32[]);
+    function getAllModulesAndPermsFromTypes(address _delegate, uint8[] _types) external view returns(address[], bytes32[]);
 
     /**
     * @notice Use to get the Permission flag related the `this` contract

--- a/test/g_general_permission_manager.js
+++ b/test/g_general_permission_manager.js
@@ -370,7 +370,7 @@ contract('GeneralPermissionManager', accounts => {
         })
 
         it("Should return all modules and all permission", async() => {
-            let tx = await I_GeneralPermissionManager.getAllModulesAndPermsFromTypes.call(account_delegate3, [2,1], I_SecurityToken.address);
+            let tx = await I_GeneralPermissionManager.getAllModulesAndPermsFromTypes.call(account_delegate3, [2,1]);
             assert.equal(tx[0][0], I_GeneralTransferManager.address);
             assert.equal(tx[1][0], "0x57484954454c4953540000000000000000000000000000000000000000000000");
             assert.equal(tx[0][1], I_GeneralPermissionManager.address);


### PR DESCRIPTION
getAllModulesAndPermsFromTypes() in general permission manager now reads security token address from storage rather than as a function parameter.

This might require CLI and dApp changes.