### PR TITLE
KindMath replaced by SafeMath

### DIFF
--- a/contracts/libraries/TokenLib.sol
+++ b/contracts/libraries/TokenLib.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.4.24;
 
 import "../modules/PermissionManager/IPermissionManager.sol";
-import "./KindMath.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 library TokenLib {
 
-    using KindMath for uint256;
+    using SafeMath for uint256;
 
     // Struct for module data
     struct ModuleData {


### PR DESCRIPTION
Not so kind math (SafeMath) is now used rather than kind math in TokenLib for consistency.