### PR TITLE
Fixed docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install:
   - echo -ne '\n' | sudo add-apt-repository ppa:ethereum/ethereum 
   - sudo apt-get -y update  
   - sudo apt-get -y install solc
+  - sudo apt-get -y install libz3
+  - sudo apt-get -y install libz3-dev
 matrix:
   fast_finish: true
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,24 @@ node_js:
 cache:
   directories:
   - node_modules
-before_install: 
-  - echo -ne '\n' | sudo apt-add-repository -y ppa:hvr/z3
-  - sudo apt-get -y update
-  - sudo apt-get -y install libz3-dev
 matrix:
   fast_finish: true
-before_script:
-  - truffle version
-  - wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
-  - wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
-script:
-  - npm run docs
-  - npm run test
+  allow_failures:
+    - env: 'TASK=docs'
+jobs:
+  include:
+    - stage: Tests and Coverage
+      after_install: wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+      before_script: truffle version
+      script: npm run test
+    - stage: Docs
+      env: 'TASK=docs'
+      before_install: 
+        - echo -ne '\n' | sudo apt-add-repository -y ppa:hvr/z3
+        - sudo apt-get -y update
+        - sudo apt-get -y install libz3-dev 
+      before_script: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+      script: npm run docs
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,21 @@ cache:
   - node_modules
 matrix:
   fast_finish: true
-before_script:
-  - truffle version
-  - wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
-  - wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
-script:
-  - npm run test
-  - npm run docs
+  allow_failures:
+    - env: 'TASK=docs'
+jobs:
+  include:
+    - stage: Tests and Coverage
+      install: yarn install
+      after_install: wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+      before_script: truffle version
+      script: npm run test
+    - stage: docs
+      env: 'TASK=docs'
+      before_install: sudo apt-get -y install build-essential libboost-all-dev libz3-dev
+      install: yarn install
+      after_install: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+      script: npm run docs
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
 before_script:
   - truffle version
   - wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+  - wget -O node_modules/solidity-docgen/buffer-size/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
 script:
   - npm run test
+  - npm run docs
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 before_script:
   - truffle version
   - wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
-  - wget -O node_modules/solidity-docgen/buffer-size/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+  - wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
 script:
   - npm run test
   - npm run docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,18 @@ matrix:
     - env: 'TASK=docs'
 jobs:
   include:
+    - stage: Docs
+      env: 'TASK=docs'
+      before_install: sudo add-apt-repository universe
+      install: yarn install
+      after_install: sudo apt-get -y install build-essential libboost-all-dev libz3-dev
+      before_script: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+      script: npm run docs
     - stage: Tests and Coverage
       install: yarn install
       after_install: wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
       before_script: truffle version
       script: npm run test
-    - stage: docs
-      env: 'TASK=docs'
-      before_install: sudo apt-get -y install build-essential libboost-all-dev libz3-dev
-      install: yarn install
-      after_install: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
-      script: npm run docs
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,19 @@ node_js:
 cache:
   directories:
   - node_modules
+before_install: 
+  - sudo add-apt-repository ppa:ethereum/ethereum 
+  - sudo apt-get -y update  
+  - sudo apt-get -y install solc
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: 'TASK=docs'
-jobs:
-  include:
-    - stage: Docs
-      env: 'TASK=docs'
-      before_install: sudo add-apt-repository universe
-      install: yarn install
-      after_install: sudo apt-get -y install build-essential libboost-all-dev libz3-dev
-      before_script: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
-      script: npm run docs
-    - stage: Tests and Coverage
-      install: yarn install
-      after_install: wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
-      before_script: truffle version
-      script: npm run test
+before_script:
+  - truffle version
+  - wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+  - wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+script:
+  - npm run docs
+  - npm run test
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - node_modules
 before_install: 
-  - sudo add-apt-repository ppa:ethereum/ethereum 
+  - echo -ne '\n' | sudo add-apt-repository ppa:ethereum/ethereum 
   - sudo apt-get -y update  
   - sudo apt-get -y install solc
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ cache:
   directories:
   - node_modules
 before_install: 
-  - echo -ne '\n' | sudo add-apt-repository ppa:ethereum/ethereum 
-  - sudo apt-get -y update  
-  - sudo apt-get -y install solc
-  - sudo apt-get -y install libz3
+  - echo -ne '\n' | sudo apt-add-repository -y ppa:hvr/z3
+  - sudo apt-get -y update
   - sudo apt-get -y install libz3-dev
 matrix:
   fast_finish: true

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -32,12 +32,20 @@ create_docs() {
     cd $WEBSITE_DIRECTORY
     fi
 
+    echo "Fetching solc binary"
+    curl -L -o solidity-ubuntu-trusty.zip https://github.com/ethereum/solidity/releases/download/v0.4.24/solidity-ubuntu-trusty.zip
+    unzip solidity-ubuntu-trusty.zip
+    CWD=$(pwd)
+    OLD_SOLC_PATH=$SOLC_PATH
+    export SOLC_PATH=$CWD/solc
     echo "Generating the API documentation in branch $latestTag"
     # Command to generate the documentation using the solidity-docgen
 
     migrate=$(SOLC_ARGS="openzeppelin-solidity="$CORE_ROUTE"/node_modules/openzeppelin-solidity" \
 solidity-docgen -x external/oraclizeAPI.sol,mocks/MockPolyOracle.sol,oracles/PolyOracle.sol $CORE_ROUTE $CORE_ROUTE/contracts $CORE_ROUTE/polymath-developer-portal/)
     
+    export SOLC_PATH=$OLD_SOLC_PATH
+
     echo "Successfully docs are generated..."
     
     echo "Installing npm dependencies..."

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -38,6 +38,7 @@ create_docs() {
     CWD=$(pwd)
     OLD_SOLC_PATH=$SOLC_PATH
     export SOLC_PATH=$CWD/solc
+    curl -o node_modules/solidity-docgen/buffer-size/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
     echo "Generating the API documentation in branch $latestTag"
     # Command to generate the documentation using the solidity-docgen
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -38,7 +38,7 @@ create_docs() {
     CWD=$(pwd)
     OLD_SOLC_PATH=$SOLC_PATH
     export SOLC_PATH=$CWD/solc
-    curl -o node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+
     echo "Generating the API documentation in branch $latestTag"
     # Command to generate the documentation using the solidity-docgen
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -38,7 +38,7 @@ create_docs() {
     CWD=$(pwd)
     OLD_SOLC_PATH=$SOLC_PATH
     export SOLC_PATH=$CWD/solc
-    curl -o node_modules/solidity-docgen/buffer-size/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
+    curl -o node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
     echo "Generating the API documentation in branch $latestTag"
     # Command to generate the documentation using the solidity-docgen
 


### PR DESCRIPTION
- Fixed OpenZeppelin solidity-docgen (https://github.com/OpenZeppelin/solidity-docgen/pull/17)
- Modified our script to fetch solc 0.4.24 instead of latest (0.5.0)
- Modified Travis script to fetch required dependencies
- Split the docs generation into a separate optional job that builds won't fail even if docs fail for some reason