### PR TITLE
Fetch poly token from pm registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ All notable changes to this project will be documented in this file.
 * Fixed `addModule` function to be backwards compatible and call the new `addModuleWithLabel` function with an empty label. 
 * Fixed event `ModuleAdded` to also emit `_label`.    
 * Fixed function `getModule` to also return the respective module label.
+* Replaced `updatePolyTokenAddress()` function with `updateFromRegistry()` in `SecurityTokenRegistry`.  
 
 ## Removed
 * Removed `_polyAddress` parameter from constructors of all modules and module factories.
 * Removed `_polyToken` parameter from `initialize` function in `SecurityTokenRegistry`.
-* Removed  `updatePolyTokenAddress` function in `SecurityTokenRegistry`.   
+ 
 
 # v1.5.0 - Release Candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ All notable changes to this project will be documented in this file.
 * Added new function `addModuleWithLabel()` which takes an extra param `_label` that used for giving the customize label to the module for display purpose. #428   
 * Fixed `addModule` function to be backwards compatible and call the new `addModuleWithLabel` function with an empty label.  
 * Fixed event `ModuleAdded` to also emit `_label`.    
-* Fixed function `getModule` to also return the respective module label.   
+* Fixed function `getModule` to also return the respective module label.
+* Removed `_polyAddress` parameter from constructors of all modules and module factories.
+* Removed `_polyToken` parameter from `initialize` function in `SecurityTokenRegistry`.
+* Removed  `updatePolyTokenAddress` function in `SecurityTokenRegistry`.   
 
 # v1.5.0 - Release Candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 
 [__3.0.0__](https://www.npmjs.com/package/polymath-core?activeTab=readme) __10-11-18__
 
-## SecurityToken
-* Added new function `addModuleWithLabel()` which takes an extra param `_label` that used for giving the customize label to the module for display purpose. #428   
-* Fixed `addModule` function to be backwards compatible and call the new `addModuleWithLabel` function with an empty label.  
+## Added
+* Added new function `addModuleWithLabel()` which takes an extra param `_label` that used for giving the customize label to the module for display purpose. #428
+
+## Fixed
+* Fixed `addModule` function to be backwards compatible and call the new `addModuleWithLabel` function with an empty label. 
 * Fixed event `ModuleAdded` to also emit `_label`.    
 * Fixed function `getModule` to also return the respective module label.
+
+## Removed
 * Removed `_polyAddress` parameter from constructors of all modules and module factories.
 * Removed `_polyToken` parameter from `initialize` function in `SecurityTokenRegistry`.
 * Removed  `updatePolyTokenAddress` function in `SecurityTokenRegistry`.   

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -5,6 +5,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IOwnable.sol";
 import "./interfaces/ISTFactory.sol";
 import "./interfaces/ISecurityTokenRegistry.sol";
+import "./interfaces/IPolymathRegistry.sol";
 import "./storage/EternalStorage.sol";
 import "./libraries/Util.sol";
 import "./libraries/Encoder.sol";
@@ -181,7 +182,6 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
             "Invalid address"
         );
         require(_stLaunchFee != 0 && _tickerRegFee != 0, "Fees should not be 0");
-        set(POLYTOKEN, _polyToken);
         set(STLAUNCHFEE, _stLaunchFee);
         set(TICKERREGFEE, _tickerRegFee);
         set(EXPIRYLIMIT, uint256(60 * 1 days));
@@ -747,6 +747,14 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
     function updatePolyTokenAddress(address _newAddress) external onlyOwner {
         require(_newAddress != address(0), "Invalid address");
         set(POLYTOKEN, _newAddress);
+    }
+
+    /**
+     * @notice Stores the contract addresses of other key contracts from the PolymathRegistry
+     */
+    function updateFromRegistry() external onlyOwner {
+        address _polymathRegistry = getAddress(Encoder.getKey("polymathRegistry"));
+        set(Encoder.getKey("polyToken"), IPolymathRegistry(_polymathRegistry).getAddress("PolyToken"));
     }
 
     /**

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -191,6 +191,13 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
         _updateFromRegistry();
     }
 
+    /**
+     * @notice Used to update the polyToken contract address
+     */
+    function updateFromRegistry() external OnlyOwner {
+        _updateFromRegistry();
+    }
+
     function _updateFromRegistry() internal {
         address polymathRegistry = getAddress(POLYMATHREGISTRY);
         set(POLYTOKEN, IPolymathRegistry(polymathRegistry).getAddress("PolyToken"));

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -188,6 +188,12 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
         set(POLYMATHREGISTRY, _polymathRegistry);
         _setProtocolVersion(_STFactory, uint8(2), uint8(0), uint8(0));
         set(INITIALIZE, true);
+        _updateFromRegistry();
+    }
+
+    function _updateFromRegistry() internal {
+        address polymathRegistry = getAddress(POLYMATHREGISTRY);
+        set(POLYTOKEN, IPolymathRegistry(polymathRegistry).getAddress("PolyToken"));
     }
 
     /////////////////////////////
@@ -736,14 +742,6 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
      */
     function getProtocolVersion() public view returns(uint8[]) {
         return VersionUtils.unpack(uint24(getUint(Encoder.getKey("latestVersion"))));
-    }
-
-    /**
-     * @notice Stores the contract addresses of other key contracts from the PolymathRegistry
-     */
-    function updateFromRegistry() external onlyOwner {
-        address _polymathRegistry = getAddress(Encoder.getKey("polymathRegistry"));
-        set(Encoder.getKey("polyToken"), IPolymathRegistry(_polymathRegistry).getAddress("PolyToken"));
     }
 
     /**

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -162,7 +162,6 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
      * @param _STFactory is the address of the Proxy contract for Security Tokens
      * @param _stLaunchFee is the fee in POLY required to launch a token
      * @param _tickerRegFee is the fee in POLY required to register a ticker
-     * @param _polyToken is the address of the POLY ERC20 token
      * @param _owner is the owner of the STR
      */
     function initialize(
@@ -170,7 +169,6 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
         address _STFactory,
         uint256 _stLaunchFee,
         uint256 _tickerRegFee,
-        address _polyToken,
         address _owner
     )
         external
@@ -178,7 +176,7 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
     {
         require(!getBool(INITIALIZE),"already initialized");
         require(
-            _STFactory != address(0) && _polyToken != address(0) && _owner != address(0) && _polymathRegistry != address(0),
+            _STFactory != address(0) && _owner != address(0) && _polymathRegistry != address(0),
             "Invalid address"
         );
         require(_stLaunchFee != 0 && _tickerRegFee != 0, "Fees should not be 0");

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -194,7 +194,7 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
     /**
      * @notice Used to update the polyToken contract address
      */
-    function updateFromRegistry() external OnlyOwner {
+    function updateFromRegistry() external onlyOwner {
         _updateFromRegistry();
     }
 

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -739,15 +739,6 @@ contract SecurityTokenRegistry is ISecurityTokenRegistry, EternalStorage {
     }
 
     /**
-     * @notice Changes the PolyToken address. Only Polymath.
-     * @param _newAddress is the address of the polytoken.
-     */
-    function updatePolyTokenAddress(address _newAddress) external onlyOwner {
-        require(_newAddress != address(0), "Invalid address");
-        set(POLYTOKEN, _newAddress);
-    }
-
-    /**
      * @notice Stores the contract addresses of other key contracts from the PolymathRegistry
      */
     function updateFromRegistry() external onlyOwner {

--- a/contracts/interfaces/ISecurityTokenRegistry.sol
+++ b/contracts/interfaces/ISecurityTokenRegistry.sol
@@ -170,11 +170,6 @@ interface ISecurityTokenRegistry {
    function changeSecurityLaunchFee(uint256 _stLaunchFee) external;
 
     /**
-     * @notice Use to get the latest contract address of the regstries
-     */
-    function updateFromRegistry() external;
-
-    /**
      * @notice Gets the security token launch fee
      * @return Fee amount
      */

--- a/contracts/interfaces/ISecurityTokenRegistry.sol
+++ b/contracts/interfaces/ISecurityTokenRegistry.sol
@@ -170,10 +170,9 @@ interface ISecurityTokenRegistry {
    function changeSecurityLaunchFee(uint256 _stLaunchFee) external;
 
     /**
-     * @notice Change the PolyToken address
-     * @param _newAddress Address of the polytoken
+     * @notice Use to get the latest contract address of the regstries
      */
-    function updatePolyTokenAddress(address _newAddress) external;
+    function updateFromRegistry() external;
 
     /**
      * @notice Gets the security token launch fee

--- a/contracts/interfaces/IUSDTieredSTOProxy.sol
+++ b/contracts/interfaces/IUSDTieredSTOProxy.sol
@@ -8,11 +8,10 @@ interface IUSDTieredSTOProxy {
    /**
      * @notice Deploys the STO.
      * @param _securityToken Contract address of the securityToken
-     * @param _polyAddress Contract address of the PolyToken
-     * @param _factoryAddress Contract address of the factory 
+     * @param _factoryAddress Contract address of the factory
      * @return address Address of the deployed STO
      */
-    function deploySTO(address _securityToken, address _polyAddress, address _factoryAddress) external returns (address);
+    function deploySTO(address _securityToken, address _factoryAddress) external returns (address);
     
      /**
      * @notice Used to get the init function signature

--- a/contracts/mocks/MockBurnFactory.sol
+++ b/contracts/mocks/MockBurnFactory.sol
@@ -9,9 +9,12 @@ import "../modules/Experimental/Burn/TrackedRedemptionFactory.sol";
 
 contract MockBurnFactory is TrackedRedemptionFactory {
 
-     /**
-     * @notice Constructor
-     */
+    /**
+    * @notice Constructor
+    * @param _setupCost Setup cost of the module
+    * @param _usageCost Usage cost of the module
+    * @param _subscriptionCost Subscription cost of the module
+    */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
       TrackedRedemptionFactory(_setupCost, _usageCost, _subscriptionCost)
     {
@@ -22,9 +25,10 @@ contract MockBurnFactory is TrackedRedemptionFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /*_data*/) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Unable to pay setup cost");
+        }
         //Check valid bytes - can only call module init function
         MockRedemptionManager mockRedemptionManager = new MockRedemptionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/

--- a/contracts/mocks/MockBurnFactory.sol
+++ b/contracts/mocks/MockBurnFactory.sol
@@ -25,10 +25,7 @@ contract MockBurnFactory is TrackedRedemptionFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /*_data*/) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Unable to pay setup cost");
-        }
+        _takeFee();
         //Check valid bytes - can only call module init function
         MockRedemptionManager mockRedemptionManager = new MockRedemptionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/

--- a/contracts/mocks/MockBurnFactory.sol
+++ b/contracts/mocks/MockBurnFactory.sol
@@ -11,10 +11,9 @@ contract MockBurnFactory is TrackedRedemptionFactory {
 
      /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-      TrackedRedemptionFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+      TrackedRedemptionFactory(_setupCost, _usageCost, _subscriptionCost)
     {
     }
 
@@ -23,6 +22,7 @@ contract MockBurnFactory is TrackedRedemptionFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /*_data*/) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Unable to pay setup cost");
         //Check valid bytes - can only call module init function

--- a/contracts/mocks/MockBurnFactory.sol
+++ b/contracts/mocks/MockBurnFactory.sol
@@ -26,7 +26,7 @@ contract MockBurnFactory is TrackedRedemptionFactory {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Unable to pay setup cost");
         //Check valid bytes - can only call module init function
-        MockRedemptionManager mockRedemptionManager = new MockRedemptionManager(msg.sender, address(polyToken));
+        MockRedemptionManager mockRedemptionManager = new MockRedemptionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(mockRedemptionManager), getName(), address(this), msg.sender, setupCost, now);
         return address(mockRedemptionManager);

--- a/contracts/mocks/MockBurnFactory.sol
+++ b/contracts/mocks/MockBurnFactory.sol
@@ -25,8 +25,8 @@ contract MockBurnFactory is TrackedRedemptionFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /*_data*/) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Unable to pay setup cost");
         }
         //Check valid bytes - can only call module init function

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -9,8 +9,12 @@ import "../modules/STO/DummySTOFactory.sol";
 contract MockFactory is DummySTOFactory {
 
     bool public switchTypes = false;
-     /**
+
+    /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
       DummySTOFactory(_setupCost, _usageCost, _subscriptionCost)

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -11,10 +11,9 @@ contract MockFactory is DummySTOFactory {
     bool public switchTypes = false;
      /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-      DummySTOFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+      DummySTOFactory(_setupCost, _usageCost, _subscriptionCost)
     {
 
     }

--- a/contracts/mocks/MockRedemptionManager.sol
+++ b/contracts/mocks/MockRedemptionManager.sol
@@ -14,10 +14,9 @@ contract MockRedemptionManager is TrackedRedemption {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    TrackedRedemption(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    TrackedRedemption(_securityToken)
     {
     }
 

--- a/contracts/mocks/MockWrongTypeFactory.sol
+++ b/contracts/mocks/MockWrongTypeFactory.sol
@@ -12,10 +12,9 @@ contract MockWrongTypeFactory is MockBurnFactory {
 
      /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-      MockBurnFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+      MockBurnFactory(_setupCost, _usageCost, _subscriptionCost)
     {
     }
 

--- a/contracts/mocks/MockWrongTypeFactory.sol
+++ b/contracts/mocks/MockWrongTypeFactory.sol
@@ -10,9 +10,12 @@ import "../libraries/Util.sol";
 
 contract MockWrongTypeFactory is MockBurnFactory {
 
-     /**
-     * @notice Constructor
-     */
+    /**
+    * @notice Constructor
+    * @param _setupCost Setup cost of the module
+    * @param _usageCost Usage cost of the module
+    * @param _subscriptionCost Subscription cost of the module
+    */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
       MockBurnFactory(_setupCost, _usageCost, _subscriptionCost)
     {

--- a/contracts/mocks/TestSTOFactory.sol
+++ b/contracts/mocks/TestSTOFactory.sol
@@ -6,10 +6,9 @@ contract TestSTOFactory is DummySTOFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-      DummySTOFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+      DummySTOFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "TestSTO";

--- a/contracts/mocks/TestSTOFactory.sol
+++ b/contracts/mocks/TestSTOFactory.sol
@@ -6,6 +6,9 @@ contract TestSTOFactory is DummySTOFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
       DummySTOFactory(_setupCost, _usageCost, _subscriptionCost)

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
@@ -47,10 +47,9 @@ contract ERC20DividendCheckpoint is DividendCheckpoint {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -30,9 +30,10 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "insufficent allowance");
+        }
         address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(erc20DividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -30,8 +30,8 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "insufficent allowance");
         }
         address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender);

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -30,10 +30,7 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "insufficent allowance");
-        }
+        _takeFee();
         address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(erc20DividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -33,7 +33,7 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "insufficent allowance");
-        address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender, address(polyToken));
+        address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(erc20DividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return erc20DividendCheckpoint;

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpointFactory.sol
@@ -10,13 +10,12 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of the module
      * @param _usageCost Usage cost of the module
      * @param _subscriptionCost Subscription cost of the module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "ERC20DividendCheckpoint";
@@ -31,6 +30,7 @@ contract ERC20DividendCheckpointFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "insufficent allowance");
         address erc20DividendCheckpoint = new ERC20DividendCheckpoint(msg.sender);

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -27,10 +27,9 @@ contract EtherDividendCheckpoint is DividendCheckpoint {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -30,10 +30,7 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
-        }
+        _takeFee();
         address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(ethDividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -10,13 +10,12 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of the module
      * @param _usageCost Usage cost of the module
      * @param _subscriptionCost Subscription cost of the module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "EtherDividendCheckpoint";
@@ -31,6 +30,7 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
         address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender);

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -33,7 +33,7 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
-        address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender, address(polyToken));
+        address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(ethDividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return ethDividendCheckpoint;

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -30,9 +30,10 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
+        }
         address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(ethDividendCheckpoint, getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpointFactory.sol
@@ -30,8 +30,8 @@ contract EtherDividendCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
         }
         address ethDividendCheckpoint = new EtherDividendCheckpoint(msg.sender);

--- a/contracts/modules/Experimental/Burn/TrackedRedemption.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemption.sol
@@ -18,10 +18,9 @@ contract TrackedRedemption is IBurn, Module {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
@@ -10,13 +10,12 @@ contract TrackedRedemptionFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of module
      * @param _usageCost Usage cost of module
      * @param _subscriptionCost Monthly cost of module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "TrackedRedemption";
@@ -31,6 +30,7 @@ contract TrackedRedemptionFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
         address trackedRedemption = new TrackedRedemption(msg.sender);

--- a/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
@@ -30,10 +30,7 @@ contract TrackedRedemptionFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
-        }
+        _takeFee();
         address trackedRedemption = new TrackedRedemption(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(trackedRedemption), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
@@ -30,8 +30,8 @@ contract TrackedRedemptionFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
         }
         address trackedRedemption = new TrackedRedemption(msg.sender);

--- a/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
@@ -30,9 +30,10 @@ contract TrackedRedemptionFactory is ModuleFactory {
      * @return Address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
+        }
         address trackedRedemption = new TrackedRedemption(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(trackedRedemption), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
+++ b/contracts/modules/Experimental/Burn/TrackedRedemptionFactory.sol
@@ -33,7 +33,7 @@ contract TrackedRedemptionFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Insufficent allowance or balance");
-        address trackedRedemption = new TrackedRedemption(msg.sender, address(polyToken));
+        address trackedRedemption = new TrackedRedemption(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(trackedRedemption), getName(), address(this), msg.sender, setupCost, now);
         return address(trackedRedemption);

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpoint.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpoint.sol
@@ -32,10 +32,9 @@ contract ScheduledCheckpoint is ICheckpoint, ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
@@ -30,8 +30,8 @@ contract ScheduledCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender);

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
@@ -30,10 +30,7 @@ contract ScheduledCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender);
         emit GenerateModuleFromFactory(scheduledCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return scheduledCheckpoint;

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
@@ -30,9 +30,10 @@ contract ScheduledCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender);
         emit GenerateModuleFromFactory(scheduledCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return scheduledCheckpoint;

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
@@ -10,13 +10,12 @@ contract ScheduledCheckpointFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of the module
      * @param _usageCost Usage cost of the module
      * @param _subscriptionCost Subscription cost of the module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "ScheduledCheckpoint";
@@ -31,6 +30,7 @@ contract ScheduledCheckpointFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender);

--- a/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
+++ b/contracts/modules/Experimental/Mixed/ScheduledCheckpointFactory.sol
@@ -33,7 +33,7 @@ contract ScheduledCheckpointFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender, address(polyToken));
+        address scheduledCheckpoint = new ScheduledCheckpoint(msg.sender);
         emit GenerateModuleFromFactory(scheduledCheckpoint, getName(), address(this), msg.sender, setupCost, now);
         return scheduledCheckpoint;
     }

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTM.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTM.sol
@@ -53,11 +53,10 @@ contract LockupVolumeRestrictionTM is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress)
+    constructor (address _securityToken)
     public
-    Module(_securityToken, _polyAddress)
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
@@ -30,9 +30,10 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(lockupVolumeRestrictionTransferManager), getName(), address(this), msg.sender, now);

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
@@ -30,10 +30,7 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(lockupVolumeRestrictionTransferManager), getName(), address(this), msg.sender, now);
@@ -49,7 +46,7 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
         res[0] = 2;
         return res;
     }
-   
+
     /**
      * @notice Returns the instructions associated with the module
      */

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
@@ -10,13 +10,12 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of the module
      * @param _usageCost Usage cost of the module
      * @param _subscriptionCost Subscription cost of the module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-      ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+      ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "LockupVolumeRestrictionTM";
@@ -31,6 +30,7 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender);

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
@@ -33,7 +33,7 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender, address(polyToken));
+        LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(lockupVolumeRestrictionTransferManager), getName(), address(this), msg.sender, now);
         return address(lockupVolumeRestrictionTransferManager);

--- a/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/LockupVolumeRestrictionTMFactory.sol
@@ -30,8 +30,8 @@ contract LockupVolumeRestrictionTMFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         LockupVolumeRestrictionTM lockupVolumeRestrictionTransferManager = new LockupVolumeRestrictionTM(msg.sender);

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTM.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTM.sol
@@ -45,10 +45,9 @@ contract SingleTradeVolumeRestrictionTM is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
     */
-    constructor(address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor(address _securityToken) public
+    Module(_securityToken)
     {
 
     }

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
@@ -12,13 +12,12 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
 
     /**
     * @notice Constructor
-    * @param _polyAddress Address of the polytoken
     * @param _setupCost Setup cost of the module
     * @param _usageCost Usage cost of the module
     * @param _subscriptionCost Subscription cost of the module
     */
-    constructor(address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor(uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "SingleTradeVolumeRestrictionTM";
@@ -33,6 +32,7 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
     * @return address Contract address of the Module
     */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender);

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
@@ -35,7 +35,7 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
     function deploy(bytes _data) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender, address(polyToken));
+        SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender);
 
         require(Util.getSig(_data) == singleTradeVolumeRestrictionManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
@@ -32,8 +32,8 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
     * @return address Contract address of the Module
     */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender);

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
@@ -32,9 +32,10 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
     * @return address Contract address of the Module
     */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender);
 
         require(Util.getSig(_data) == singleTradeVolumeRestrictionManager.getInitFunction(), "Provided data is not valid");

--- a/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SingleTradeVolumeRestrictionTMFactory.sol
@@ -32,12 +32,8 @@ contract SingleTradeVolumeRestrictionTMFactory is ModuleFactory {
     * @return address Contract address of the Module
     */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         SingleTradeVolumeRestrictionTM singleTradeVolumeRestrictionManager = new SingleTradeVolumeRestrictionTM(msg.sender);
-
         require(Util.getSig(_data) == singleTradeVolumeRestrictionManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/
         require(address(singleTradeVolumeRestrictionManager).call(_data), "Unsuccessful call");

--- a/contracts/modules/Module.sol
+++ b/contracts/modules/Module.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "../RegistryUpdater.sol";
 import "../interfaces/IModule.sol";
 import "../interfaces/ISecurityToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
@@ -22,12 +23,11 @@ contract Module is IModule {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public {
+    constructor (address _securityToken) public {
         securityToken = _securityToken;
         factory = msg.sender;
-        polyToken = IERC20(_polyAddress);
+        polyToken = IERC20(RegistryUpdater(_securityToken).polyToken());
     }
 
     //Allows owner, factory or permissioned delegate

--- a/contracts/modules/ModuleFactory.sol
+++ b/contracts/modules/ModuleFactory.sol
@@ -12,6 +12,7 @@ import "../libraries/VersionUtils.sol";
  */
 contract ModuleFactory is IModuleFactory, Ownable {
 
+    IERC20 public polyToken;
     uint256 public usageCost;
     uint256 public monthlySubscriptionCost;
 
@@ -163,12 +164,8 @@ contract ModuleFactory is IModuleFactory, Ownable {
         return name;
     }
 
-    /**
-    * @notice Get the PolyToken
-    * @param _securityToken Address of the security token
-    */
-    function getPolyToken(address _securityToken) public view returns (IERC20) {
-        return IERC20(RegistryUpdater(_securityToken).polyToken());
+    function updateFromRegistry(address _securityToken) internal {
+        polyToken = IERC20(RegistryUpdater(_securityToken).polyToken());
     }
 
 }

--- a/contracts/modules/ModuleFactory.sol
+++ b/contracts/modules/ModuleFactory.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "../RegistryUpdater.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IModuleFactory.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
@@ -11,7 +12,6 @@ import "../libraries/VersionUtils.sol";
  */
 contract ModuleFactory is IModuleFactory, Ownable {
 
-    IERC20 public polyToken;
     uint256 public usageCost;
     uint256 public monthlySubscriptionCost;
 
@@ -42,10 +42,8 @@ contract ModuleFactory is IModuleFactory, Ownable {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public {
-        polyToken = IERC20(_polyAddress);
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public {
         setupCost = _setupCost;
         usageCost = _usageCost;
         monthlySubscriptionCost = _subscriptionCost;
@@ -163,6 +161,14 @@ contract ModuleFactory is IModuleFactory, Ownable {
     */
     function getName() public view returns(bytes32) {
         return name;
+    }
+
+    /**
+    * @notice Get the PolyToken
+    * @param _securityToken Address of the security token
+    */
+    function getPolyToken(address _securityToken) public view returns (IERC20) {
+        return IERC20(RegistryUpdater(_securityToken).polyToken());
     }
 
 }

--- a/contracts/modules/ModuleFactory.sol
+++ b/contracts/modules/ModuleFactory.sol
@@ -12,7 +12,6 @@ import "../libraries/VersionUtils.sol";
  */
 contract ModuleFactory is IModuleFactory, Ownable {
 
-    IERC20 public polyToken;
     uint256 public usageCost;
     uint256 public monthlySubscriptionCost;
 
@@ -23,9 +22,9 @@ contract ModuleFactory is IModuleFactory, Ownable {
     string public title;
 
     // @notice Allow only two variables to be stored
-    // 1. lowerBound 
+    // 1. lowerBound
     // 2. upperBound
-    // @dev (0.0.0 will act as the wildcard) 
+    // @dev (0.0.0 will act as the wildcard)
     // @dev uint24 consists packed value of uint8 _major, uint8 _minor, uint8 _patch
     mapping(string => uint24) compatibleSTVersionRange;
 
@@ -126,7 +125,7 @@ contract ModuleFactory is IModuleFactory, Ownable {
             "Must be a valid bound type"
         );
         require(_newVersion.length == 3);
-        if (compatibleSTVersionRange[_boundType] != uint24(0)) { 
+        if (compatibleSTVersionRange[_boundType] != uint24(0)) {
             uint8[] memory _currentVersion = VersionUtils.unpack(compatibleSTVersionRange[_boundType]);
             require(VersionUtils.isValidVersion(_currentVersion, _newVersion), "Failed because of in-valid version");
         }
@@ -160,12 +159,15 @@ contract ModuleFactory is IModuleFactory, Ownable {
    /**
     * @notice Get the name of the Module
     */
-    function getName() public view returns(bytes32) {
+    function getName() public view returns (bytes32) {
         return name;
     }
 
-    function updateFromRegistry(address _securityToken) internal {
-        polyToken = IERC20(RegistryUpdater(_securityToken).polyToken());
+    function _takeFee() internal {
+        if (setupCost > 0) {
+            require(IERC20(RegistryUpdater(msg.sender).polyToken()).transferFrom(msg.sender, owner(), setupCost),
+                "Insufficient allowance for module fee");
+        }
     }
 
 }

--- a/contracts/modules/PermissionManager/GeneralPermissionManager.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManager.sol
@@ -26,8 +26,8 @@ contract GeneralPermissionManager is IPermissionManager, Module {
 
 
     /// @notice constructor
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -30,10 +30,7 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
-        }
+        _takeFee();
         address permissionManager = new GeneralPermissionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(permissionManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -10,10 +10,9 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "GeneralPermissionManager";
@@ -28,6 +27,7 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
         address permissionManager = new GeneralPermissionManager(msg.sender);

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -10,6 +10,9 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -27,9 +30,10 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
+        }
         address permissionManager = new GeneralPermissionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(permissionManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -30,7 +30,7 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
-        address permissionManager = new GeneralPermissionManager(msg.sender, address(polyToken));
+        address permissionManager = new GeneralPermissionManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(permissionManager), getName(), address(this), msg.sender, setupCost, now);
         return permissionManager;

--- a/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
+++ b/contracts/modules/PermissionManager/GeneralPermissionManagerFactory.sol
@@ -30,8 +30,8 @@ contract GeneralPermissionManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
         }
         address permissionManager = new GeneralPermissionManager(msg.sender);

--- a/contracts/modules/STO/CappedSTO.sol
+++ b/contracts/modules/STO/CappedSTO.sol
@@ -31,8 +31,8 @@ contract CappedSTO is ISTO, ReentrancyGuard {
 
     event SetAllowBeneficialInvestments(bool _allowed);
 
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -11,10 +11,9 @@ contract CappedSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "CappedSTO";
@@ -29,6 +28,7 @@ contract CappedSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -31,8 +31,8 @@ contract CappedSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -32,7 +32,7 @@ contract CappedSTOFactory is ModuleFactory {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         //Check valid bytes - can only call module init function
-        CappedSTO cappedSTO = new CappedSTO(msg.sender, address(polyToken));
+        CappedSTO cappedSTO = new CappedSTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)
         require(Util.getSig(_data) == cappedSTO.getInitFunction(), "Invalid data");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -11,6 +11,9 @@ contract CappedSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -28,9 +31,10 @@ contract CappedSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
+        }
         //Check valid bytes - can only call module init function
         CappedSTO cappedSTO = new CappedSTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)

--- a/contracts/modules/STO/CappedSTOFactory.sol
+++ b/contracts/modules/STO/CappedSTOFactory.sol
@@ -31,10 +31,7 @@ contract CappedSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
-        }
+        _takeFee();
         //Check valid bytes - can only call module init function
         CappedSTO cappedSTO = new CappedSTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)

--- a/contracts/modules/STO/DummySTO.sol
+++ b/contracts/modules/STO/DummySTO.sol
@@ -22,10 +22,9 @@ contract DummySTO is ISTO {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -11,10 +11,9 @@ contract DummySTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "DummySTO";
@@ -28,6 +27,7 @@ contract DummySTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -31,8 +31,8 @@ contract DummySTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -31,10 +31,7 @@ contract DummySTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
-        }
+        _takeFee();
         //Check valid bytes - can only call module init function
         DummySTO dummySTO = new DummySTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -31,7 +31,7 @@ contract DummySTOFactory is ModuleFactory {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         //Check valid bytes - can only call module init function
-        DummySTO dummySTO = new DummySTO(msg.sender, address(polyToken));
+        DummySTO dummySTO = new DummySTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)
         require(Util.getSig(_data) == dummySTO.getInitFunction(), "Invalid data");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/STO/DummySTOFactory.sol
+++ b/contracts/modules/STO/DummySTOFactory.sol
@@ -11,6 +11,9 @@ contract DummySTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -22,14 +25,16 @@ contract DummySTOFactory is ModuleFactory {
         compatibleSTVersionRange["lowerBound"] = VersionUtils.pack(uint8(0), uint8(0), uint8(0));
         compatibleSTVersionRange["upperBound"] = VersionUtils.pack(uint8(0), uint8(0), uint8(0));
     }
+
     /**
      * @notice Used to launch the Module with the help of factory
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
+        }
         //Check valid bytes - can only call module init function
         DummySTO dummySTO = new DummySTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)

--- a/contracts/modules/STO/PreSaleSTO.sol
+++ b/contracts/modules/STO/PreSaleSTO.sol
@@ -19,10 +19,9 @@ contract PreSaleSTO is ISTO {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress) public
-    Module(_securityToken, _polyAddress)
+    constructor (address _securityToken) public
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -32,8 +32,8 @@ contract PreSaleSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -11,6 +11,9 @@ contract PreSaleSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -29,8 +32,8 @@ contract PreSaleSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         //Check valid bytes - can only call module init function

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -34,7 +34,7 @@ contract PreSaleSTOFactory is ModuleFactory {
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         //Check valid bytes - can only call module init function
-        PreSaleSTO preSaleSTO = new PreSaleSTO(msg.sender, address(polyToken));
+        PreSaleSTO preSaleSTO = new PreSaleSTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)
         require(Util.getSig(_data) == preSaleSTO.getInitFunction(), "Invalid data");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -32,10 +32,7 @@ contract PreSaleSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
-        }
+        _takeFee();
         //Check valid bytes - can only call module init function
         PreSaleSTO preSaleSTO = new PreSaleSTO(msg.sender);
         //Checks that _data is valid (not calling anything it shouldn't)
@@ -55,7 +52,7 @@ contract PreSaleSTOFactory is ModuleFactory {
         res[0] = 3;
         return res;
     }
-    
+
     /**
      * @notice Returns the instructions associated with the module
      */

--- a/contracts/modules/STO/PreSaleSTOFactory.sol
+++ b/contracts/modules/STO/PreSaleSTOFactory.sol
@@ -11,10 +11,9 @@ contract PreSaleSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "PreSaleSTO";
@@ -30,6 +29,7 @@ contract PreSaleSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0) {
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }

--- a/contracts/modules/STO/ProxyFactory/USDTieredSTOProxyFactory.sol
+++ b/contracts/modules/STO/ProxyFactory/USDTieredSTOProxyFactory.sol
@@ -12,12 +12,11 @@ contract USDTieredSTOProxyFactory is IUSDTieredSTOProxy {
     /**
      * @notice Deploys the STO.
      * @param _securityToken Contract address of the securityToken
-     * @param _polyAddress Contract address of the PolyToken.
      * @param _factoryAddress Contract address of the factory
      * @return address Address of the deployed STO
      */
-    function deploySTO(address _securityToken, address _polyAddress, address _factoryAddress) external returns (address) {
-        address newSecurityTokenAddress = new USDTieredSTO(_securityToken, _polyAddress, _factoryAddress);
+    function deploySTO(address _securityToken, address _factoryAddress) external returns (address) {
+        address newSecurityTokenAddress = new USDTieredSTO(_securityToken, _factoryAddress);
         return newSecurityTokenAddress;
     }
 

--- a/contracts/modules/STO/USDTieredSTO.sol
+++ b/contracts/modules/STO/USDTieredSTO.sol
@@ -163,7 +163,7 @@ contract USDTieredSTO is ISTO, ReentrancyGuard {
     // STO Configuration //
     ///////////////////////
 
-    constructor (address _securityToken, address _polyAddress, address _factory) public Module(_securityToken, _polyAddress) {
+    constructor (address _securityToken, address _factory) public Module(_securityToken) {
         oracleKeys[bytes32("ETH")][bytes32("USD")] = ETH_ORACLE;
         oracleKeys[bytes32("POLY")][bytes32("USD")] = POLY_ORACLE;
         require(_factory != address(0), "In-valid address");

--- a/contracts/modules/STO/USDTieredSTOFactory.sol
+++ b/contracts/modules/STO/USDTieredSTOFactory.sol
@@ -37,10 +37,7 @@ contract USDTieredSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
-        }
+        _takeFee();
         require(USDTieredSTOProxyAddress != address(0), "Proxy contract should be pre-set");
         //Check valid bytes - can only call module init function
         address usdTieredSTO = IUSDTieredSTOProxy(USDTieredSTOProxyAddress).deploySTO(msg.sender, address(this));

--- a/contracts/modules/STO/USDTieredSTOFactory.sol
+++ b/contracts/modules/STO/USDTieredSTOFactory.sol
@@ -13,6 +13,10 @@ contract USDTieredSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
+     * @param _proxyFactoryAddress Address of the proxy factory
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost, address _proxyFactoryAddress) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -33,9 +37,10 @@ contract USDTieredSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
+        }
         require(USDTieredSTOProxyAddress != address(0), "Proxy contract should be pre-set");
         //Check valid bytes - can only call module init function
         address usdTieredSTO = IUSDTieredSTOProxy(USDTieredSTOProxyAddress).deploySTO(msg.sender, address(this));

--- a/contracts/modules/STO/USDTieredSTOFactory.sol
+++ b/contracts/modules/STO/USDTieredSTOFactory.sol
@@ -13,10 +13,9 @@ contract USDTieredSTOFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost, address _proxyFactoryAddress) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost, address _proxyFactoryAddress) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         require(_proxyFactoryAddress != address(0), "0x address is not allowed");
         USDTieredSTOProxyAddress = _proxyFactoryAddress;
@@ -34,6 +33,7 @@ contract USDTieredSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         require(USDTieredSTOProxyAddress != address(0), "Proxy contract should be pre-set");

--- a/contracts/modules/STO/USDTieredSTOFactory.sol
+++ b/contracts/modules/STO/USDTieredSTOFactory.sol
@@ -37,8 +37,8 @@ contract USDTieredSTOFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         }
         require(USDTieredSTOProxyAddress != address(0), "Proxy contract should be pre-set");

--- a/contracts/modules/STO/USDTieredSTOFactory.sol
+++ b/contracts/modules/STO/USDTieredSTOFactory.sol
@@ -38,7 +38,7 @@ contract USDTieredSTOFactory is ModuleFactory {
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Sufficent Allowance is not provided");
         require(USDTieredSTOProxyAddress != address(0), "Proxy contract should be pre-set");
         //Check valid bytes - can only call module init function
-        address usdTieredSTO = IUSDTieredSTOProxy(USDTieredSTOProxyAddress).deploySTO(msg.sender, address(polyToken), address(this));
+        address usdTieredSTO = IUSDTieredSTOProxy(USDTieredSTOProxyAddress).deploySTO(msg.sender, address(this));
         //Checks that _data is valid (not calling anything it shouldn't)
         require(Util.getSig(_data) == IUSDTieredSTOProxy(USDTieredSTOProxyAddress).getInitFunction(usdTieredSTO), "Invalid data");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/TransferManager/CountTransferManager.sol
+++ b/contracts/modules/TransferManager/CountTransferManager.sol
@@ -17,11 +17,10 @@ contract CountTransferManager is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress)
+    constructor (address _securityToken)
     public
-    Module(_securityToken, _polyAddress)
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -32,10 +32,7 @@ contract CountTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
-        }
+        _takeFee();
         CountTransferManager countTransferManager = new CountTransferManager(msg.sender);
         require(Util.getSig(_data) == countTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -32,8 +32,8 @@ contract CountTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
         }
         CountTransferManager countTransferManager = new CountTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -11,10 +11,9 @@ contract CountTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "CountTransferManager";
@@ -30,6 +29,7 @@ contract CountTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
         CountTransferManager countTransferManager = new CountTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -11,6 +11,9 @@ contract CountTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -29,9 +32,10 @@ contract CountTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
+        }
         CountTransferManager countTransferManager = new CountTransferManager(msg.sender);
         require(Util.getSig(_data) == countTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/TransferManager/CountTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/CountTransferManagerFactory.sol
@@ -32,7 +32,7 @@ contract CountTransferManagerFactory is ModuleFactory {
     function deploy(bytes _data) external returns(address) {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom due to insufficent Allowance provided");
-        CountTransferManager countTransferManager = new CountTransferManager(msg.sender, address(polyToken));
+        CountTransferManager countTransferManager = new CountTransferManager(msg.sender);
         require(Util.getSig(_data) == countTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/
         require(address(countTransferManager).call(_data), "Unsuccessful call");

--- a/contracts/modules/TransferManager/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManager.sol
@@ -68,11 +68,10 @@ contract GeneralTransferManager is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress)
+    constructor (address _securityToken)
     public
-    Module(_securityToken, _polyAddress)
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -31,10 +31,7 @@ contract GeneralTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         address generalTransferManager = new GeneralTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(generalTransferManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -31,8 +31,8 @@ contract GeneralTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         address generalTransferManager = new GeneralTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -10,6 +10,9 @@ contract GeneralTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -28,9 +31,10 @@ contract GeneralTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         address generalTransferManager = new GeneralTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(generalTransferManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -10,10 +10,9 @@ contract GeneralTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "GeneralTransferManager";
@@ -29,6 +28,7 @@ contract GeneralTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         address generalTransferManager = new GeneralTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/GeneralTransferManagerFactory.sol
@@ -31,7 +31,7 @@ contract GeneralTransferManagerFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        address generalTransferManager = new GeneralTransferManager(msg.sender, address(polyToken));
+        address generalTransferManager = new GeneralTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(generalTransferManager), getName(), address(this), msg.sender, setupCost, now);
         return address(generalTransferManager);

--- a/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManager.sol
@@ -64,11 +64,10 @@ contract ManualApprovalTransferManager is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress)
+    constructor (address _securityToken)
     public
-    Module(_securityToken, _polyAddress)
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -30,8 +30,8 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         address manualTransferManager = new ManualApprovalTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -10,13 +10,12 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      * @param _setupCost Setup cost of the module
      * @param _usageCost Usage cost of the module
      * @param _subscriptionCost Subscription cost of the module
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "ManualApprovalTransferManager";
@@ -31,6 +30,7 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         address manualTransferManager = new ManualApprovalTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -30,10 +30,7 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         address manualTransferManager = new ManualApprovalTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(manualTransferManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -30,9 +30,10 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes /* _data */) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if (setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         address manualTransferManager = new ManualApprovalTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(manualTransferManager), getName(), address(this), msg.sender, setupCost, now);

--- a/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/ManualApprovalTransferManagerFactory.sol
@@ -33,7 +33,7 @@ contract ManualApprovalTransferManagerFactory is ModuleFactory {
     function deploy(bytes /* _data */) external returns(address) {
         if (setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        address manualTransferManager = new ManualApprovalTransferManager(msg.sender, address(polyToken));
+        address manualTransferManager = new ManualApprovalTransferManager(msg.sender);
         /*solium-disable-next-line security/no-block-members*/
         emit GenerateModuleFromFactory(address(manualTransferManager), getName(), address(this), msg.sender, setupCost, now);
         return address(manualTransferManager);

--- a/contracts/modules/TransferManager/PercentageTransferManager.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManager.sol
@@ -41,11 +41,10 @@ contract PercentageTransferManager is ITransferManager {
     /**
      * @notice Constructor
      * @param _securityToken Address of the security token
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _securityToken, address _polyAddress)
+    constructor (address _securityToken)
     public
-    Module(_securityToken, _polyAddress)
+    Module(_securityToken)
     {
     }
 

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -32,7 +32,7 @@ contract PercentageTransferManagerFactory is ModuleFactory {
     function deploy(bytes _data) external returns(address) {
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender, address(polyToken));
+        PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender);
         require(Util.getSig(_data) == percentageTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/
         require(address(percentageTransferManager).call(_data), "Unsuccessful call");

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -11,10 +11,9 @@ contract PercentageTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
-     * @param _polyAddress Address of the polytoken
      */
-    constructor (address _polyAddress, uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
-    ModuleFactory(_polyAddress, _setupCost, _usageCost, _subscriptionCost)
+    constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
+    ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
     {
         version = "1.0.0";
         name = "PercentageTransferManager";
@@ -30,6 +29,7 @@ contract PercentageTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        IERC20 polyToken = getPolyToken(msg.sender);
         if(setupCost > 0)
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender);

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -32,10 +32,7 @@ contract PercentageTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        updateFromRegistry(msg.sender);
-        if (setupCost > 0) {
-            require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
-        }
+        _takeFee();
         PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender);
         require(Util.getSig(_data) == percentageTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -11,6 +11,9 @@ contract PercentageTransferManagerFactory is ModuleFactory {
 
     /**
      * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _subscriptionCost Subscription cost of the module
      */
     constructor (uint256 _setupCost, uint256 _usageCost, uint256 _subscriptionCost) public
     ModuleFactory(_setupCost, _usageCost, _subscriptionCost)
@@ -29,9 +32,10 @@ contract PercentageTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
-        IERC20 polyToken = getPolyToken(msg.sender);
-        if(setupCost > 0)
+        if (setupCost > 0) {
+            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
+        }
         PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender);
         require(Util.getSig(_data) == percentageTransferManager.getInitFunction(), "Provided data is not valid");
         /*solium-disable-next-line security/no-low-level-calls*/

--- a/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/PercentageTransferManagerFactory.sol
@@ -32,8 +32,8 @@ contract PercentageTransferManagerFactory is ModuleFactory {
      * @return address Contract address of the Module
      */
     function deploy(bytes _data) external returns(address) {
+        updateFromRegistry(msg.sender);
         if (setupCost > 0) {
-            IERC20 polyToken = getPolyToken(msg.sender);
             require(polyToken.transferFrom(msg.sender, owner(), setupCost), "Failed transferFrom because of sufficent Allowance is not provided");
         }
         PercentageTransferManager percentageTransferManager = new PercentageTransferManager(msg.sender);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -149,31 +149,31 @@ module.exports = function (deployer, network, accounts) {
   }).then(() => {
     // B) Deploy the GeneralTransferManagerFactory Contract (Factory used to generate the GeneralTransferManager contract and this
     // manager attach with the securityToken contract at the time of deployment)
-    return deployer.deploy(GeneralTransferManagerFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(GeneralTransferManagerFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // C) Deploy the GeneralPermissionManagerFactory Contract (Factory used to generate the GeneralPermissionManager contract and
     // this manager attach with the securityToken contract at the time of deployment)
-    return deployer.deploy(GeneralPermissionManagerFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(GeneralPermissionManagerFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // D) Deploy the CountTransferManagerFactory Contract (Factory used to generate the CountTransferManager contract use
     // to track the counts of the investors of the security token)
-    return deployer.deploy(CountTransferManagerFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(CountTransferManagerFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // D) Deploy the PercentageTransferManagerFactory Contract (Factory used to generate the PercentageTransferManager contract use
     // to track the percentage of investment the investors could do for a particular security token)
-    return deployer.deploy(PercentageTransferManagerFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(PercentageTransferManagerFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // D) Deploy the EtherDividendCheckpointFactory Contract (Factory used to generate the EtherDividendCheckpoint contract use
     // to provide the functionality of the dividend in terms of ETH)
-    return deployer.deploy(EtherDividendCheckpointFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(EtherDividendCheckpointFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // D) Deploy the ERC20DividendCheckpointFactory Contract (Factory used to generate the ERC20DividendCheckpoint contract use
     // to provide the functionality of the dividend in terms of ERC20 token)
-    return deployer.deploy(ERC20DividendCheckpointFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+    return deployer.deploy(ERC20DividendCheckpointFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
       // D) Deploy the ManualApprovalTransferManagerFactory Contract (Factory used to generate the ManualApprovalTransferManager contract use
       // to manual approve the transfer that will overcome the other transfer restrictions)
-      return deployer.deploy(ManualApprovalTransferManagerFactory, PolyToken, 0, 0, 0, {from: PolymathAccount});
+      return deployer.deploy(ManualApprovalTransferManagerFactory, 0, 0, 0, {from: PolymathAccount});
   }).then(() => {
     // H) Deploy the STVersionProxy001 Contract which contains the logic of deployment of securityToken.
     return deployer.deploy(STFactory, GeneralTransferManagerFactory.address, {from: PolymathAccount});
@@ -262,7 +262,7 @@ module.exports = function (deployer, network, accounts) {
     return moduleRegistry.verifyModule(ManualApprovalTransferManagerFactory.address, true, {from: PolymathAccount});
   }).then(() => {
     // M) Deploy the CappedSTOFactory (Use to generate the CappedSTO contract which will used to collect the funds ).
-    return deployer.deploy(CappedSTOFactory, PolyToken, cappedSTOSetupCost, 0, 0, {from: PolymathAccount})
+    return deployer.deploy(CappedSTOFactory, cappedSTOSetupCost, 0, 0, {from: PolymathAccount})
   }).then(() => {
     // N) Register the CappedSTOFactory in the ModuleRegistry to make the factory available at the protocol level.
     // So any securityToken can use that factory to generate the CappedSTOFactory contract.
@@ -277,7 +277,7 @@ module.exports = function (deployer, network, accounts) {
     return deployer.deploy(USDTieredSTOProxyFactory, {from: PolymathAccount});
   }).then(() => {
     // H) Deploy the USDTieredSTOFactory (Use to generate the USDTieredSTOFactory contract which will used to collect the funds ).
-    return deployer.deploy(USDTieredSTOFactory, PolyToken, usdTieredSTOSetupCost, 0, 0, USDTieredSTOProxyFactory.address, {from: PolymathAccount})
+    return deployer.deploy(USDTieredSTOFactory, usdTieredSTOSetupCost, 0, 0, USDTieredSTOProxyFactory.address, {from: PolymathAccount})
   }).then(() => {
     // I) Register the USDTieredSTOFactory in the ModuleRegistry to make the factory available at the protocol level.
     // So any securityToken can use that factory to generate the USDTieredSTOFactory contract.

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -34,7 +34,6 @@ const Web3 = require('web3')
 module.exports = function (deployer, network, accounts) {
   // Ethereum account address hold by the Polymath (Act as the main account which have ownable permissions)
   let PolymathAccount;
-  let securityTokenRegistry;
   let moduleRegistry;
   let polymathRegistry;
   let web3
@@ -187,15 +186,11 @@ module.exports = function (deployer, network, accounts) {
   }).then(()=> {
     return deployer.deploy(SecurityTokenRegistryProxy, {from: PolymathAccount});
   }).then(() => {
-    securityTokenRegistry = SecurityTokenRegistry.at(SecurityTokenRegistryProxy.address);
     let bytesProxy = web3.eth.abi.encodeFunctionCall(functionSignatureProxy, [PolymathRegistry.address, STFactory.address, initRegFee, initRegFee, PolymathAccount]);
     return SecurityTokenRegistryProxy.at(SecurityTokenRegistryProxy.address).upgradeToAndCall("1.0.0", SecurityTokenRegistry.address, bytesProxy, {from: PolymathAccount});
   }).then(() => {
     // Assign the address into the SecurityTokenRegistry key
    return polymathRegistry.changeAddress("SecurityTokenRegistry", SecurityTokenRegistryProxy.address, {from: PolymathAccount});
-  }).then(() => {
-      // Update all addresses into the registry contract by calling the function updateFromregistry
-      return securityTokenRegistry.updateFromRegistry({from: PolymathAccount});
   }).then(() => {
     // Update all addresses into the registry contract by calling the function updateFromregistry
     return moduleRegistry.updateFromRegistry({from: PolymathAccount});

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -34,6 +34,7 @@ const Web3 = require('web3')
 module.exports = function (deployer, network, accounts) {
   // Ethereum account address hold by the Polymath (Act as the main account which have ownable permissions)
   let PolymathAccount;
+  let securityTokenRegistry;
   let moduleRegistry;
   let polymathRegistry;
   let web3
@@ -186,11 +187,15 @@ module.exports = function (deployer, network, accounts) {
   }).then(()=> {
     return deployer.deploy(SecurityTokenRegistryProxy, {from: PolymathAccount});
   }).then(() => {
+    securityTokenRegistry = SecurityTokenRegistry.at(SecurityTokenRegistryProxy.address);
     let bytesProxy = web3.eth.abi.encodeFunctionCall(functionSignatureProxy, [PolymathRegistry.address, STFactory.address, initRegFee, initRegFee, PolymathAccount]);
     return SecurityTokenRegistryProxy.at(SecurityTokenRegistryProxy.address).upgradeToAndCall("1.0.0", SecurityTokenRegistry.address, bytesProxy, {from: PolymathAccount});
   }).then(() => {
     // Assign the address into the SecurityTokenRegistry key
    return polymathRegistry.changeAddress("SecurityTokenRegistry", SecurityTokenRegistryProxy.address, {from: PolymathAccount});
+  }).then(() => {
+      // Update all addresses into the registry contract by calling the function updateFromregistry
+      return securityTokenRegistry.updateFromRegistry({from: PolymathAccount});
   }).then(() => {
     // Update all addresses into the registry contract by calling the function updateFromregistry
     return moduleRegistry.updateFromRegistry({from: PolymathAccount});

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -102,9 +102,6 @@ module.exports = function (deployer, network, accounts) {
         name: '_tickerRegFee'
     },{
         type: 'address',
-        name: '_polyToken'
-    },{
-        type: 'address',
         name: '_owner'
     }]
   };
@@ -189,7 +186,7 @@ module.exports = function (deployer, network, accounts) {
   }).then(()=> {
     return deployer.deploy(SecurityTokenRegistryProxy, {from: PolymathAccount});
   }).then(() => {
-    let bytesProxy = web3.eth.abi.encodeFunctionCall(functionSignatureProxy, [PolymathRegistry.address, STFactory.address, initRegFee, initRegFee, PolyToken, PolymathAccount]);
+    let bytesProxy = web3.eth.abi.encodeFunctionCall(functionSignatureProxy, [PolymathRegistry.address, STFactory.address, initRegFee, initRegFee, PolymathAccount]);
     return SecurityTokenRegistryProxy.at(SecurityTokenRegistryProxy.address).upgradeToAndCall("1.0.0", SecurityTokenRegistry.address, bytesProxy, {from: PolymathAccount});
   }).then(() => {
     // Assign the address into the SecurityTokenRegistry key

--- a/test/b_capped_sto.js
+++ b/test/b_capped_sto.js
@@ -129,7 +129,7 @@ contract("CappedSTO", accounts => {
         ] = instances;
 
         // STEP 5: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
         
         // STEP 6: Deploy the CappedSTOFactory
 

--- a/test/b_capped_sto.js
+++ b/test/b_capped_sto.js
@@ -133,7 +133,7 @@ contract("CappedSTO", accounts => {
         
         // STEP 6: Deploy the CappedSTOFactory
 
-        I_CappedSTOFactory = await CappedSTOFactory.new(I_PolyToken.address, cappedSTOSetupCost, 0, 0, { from: token_owner });
+        I_CappedSTOFactory = await CappedSTOFactory.new(cappedSTOSetupCost, 0, 0, { from: token_owner });
 
         assert.notEqual(
             I_CappedSTOFactory.address.valueOf(),

--- a/test/d_count_transfer_manager.js
+++ b/test/d_count_transfer_manager.js
@@ -100,9 +100,9 @@ contract("CountTransferManager", accounts => {
         ] = instances;
 
         // STEP 2: Deploy the CountTransferManager
-        [I_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 3: Deploy Paid the CountTransferManager
-        [P_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500", "ether"));
+        [P_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500", "ether"));
 
         // Printing all the contract addresses
         console.log(`

--- a/test/e_erc20_dividends.js
+++ b/test/e_erc20_dividends.js
@@ -107,8 +107,8 @@ contract("ERC20DividendCheckpoint", accounts => {
             I_STRProxied
         ] = instances;
 
-        [P_ERC20DividendCheckpointFactory] = await deployERC20DividendAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500", "ether"));
-        [I_ERC20DividendCheckpointFactory] = await deployERC20DividendAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [P_ERC20DividendCheckpointFactory] = await deployERC20DividendAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500", "ether"));
+        [I_ERC20DividendCheckpointFactory] = await deployERC20DividendAndVerifyed(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`
@@ -878,7 +878,7 @@ contract("ERC20DividendCheckpoint", accounts => {
         });
 
         it("should registr a delegate", async () => {
-            [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+            [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
             let tx = await I_SecurityToken.addModule(I_GeneralPermissionManagerFactory.address, "0x", 0, 0, { from: token_owner });
             assert.equal(tx.logs[2].args._types[0].toNumber(), delegateManagerKey, "General Permission Manager doesn't get deployed");
             assert.equal(

--- a/test/f_ether_dividends.js
+++ b/test/f_ether_dividends.js
@@ -103,8 +103,8 @@ contract("EtherDividendCheckpoint", accounts => {
              I_STRProxied
          ] = instances;
 
-        [P_EtherDividendCheckpointFactory] = await deployEtherDividendAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500", "ether"));
-        [I_EtherDividendCheckpointFactory] = await deployEtherDividendAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [P_EtherDividendCheckpointFactory] = await deployEtherDividendAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500", "ether"));
+        [I_EtherDividendCheckpointFactory] = await deployEtherDividendAndVerifyed(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`
@@ -792,7 +792,7 @@ contract("EtherDividendCheckpoint", accounts => {
         });
 
         it("should registr a delegate", async () => {
-            [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+            [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
             let tx = await I_SecurityToken.addModule(I_GeneralPermissionManagerFactory.address, "0x", 0, 0, { from: token_owner });
             assert.equal(tx.logs[2].args._types[0].toNumber(), delegateManagerKey, "General Permission Manager doesn't get deployed");
             assert.equal(

--- a/test/g_general_permission_manager.js
+++ b/test/g_general_permission_manager.js
@@ -103,9 +103,9 @@ contract('GeneralPermissionManager', accounts => {
         ] = instances;
 
         // STEP 5: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 6: Deploy the GeneralDelegateManagerFactory
-        [P_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+        [P_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500"));
 
         // Printing all the contract addresses
         console.log(`

--- a/test/h_general_transfer_manager.js
+++ b/test/h_general_transfer_manager.js
@@ -114,10 +114,10 @@ contract("GeneralTransferManager", accounts => {
             I_STRProxied
         ] = instances;
 
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-        [P_GeneralTransferManagerFactory] = await deployGTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
-        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-        [P_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
+        [P_GeneralTransferManagerFactory] = await deployGTMAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500"));
+        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, 0);
+        [P_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500"));
 
         // Printing all the contract addresses
         console.log(`

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -177,6 +177,7 @@ async function setInPolymathRegistry(account_polymath) {
     await I_PolymathRegistry.changeAddress("FeatureRegistry", I_FeatureRegistry.address, { from: account_polymath });
     await I_PolymathRegistry.changeAddress("SecurityTokenRegistry", I_SecurityTokenRegistryProxy.address, { from: account_polymath });
     await I_MRProxied.updateFromRegistry({ from: account_polymath });
+    await I_STRProxied.updateFromRegistry({ from: account_polymath });
 }
 
 async function registerGTM(account_polymath) {

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -128,7 +128,7 @@ async function deployModuleRegistry(account_polymath) {
 }
 
 async function deployGTM(account_polymath) {
-    I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(I_PolyToken.address, 0, 0, 0, { from: account_polymath });
+    I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(0, 0, 0, { from: account_polymath });
 
     assert.notEqual(
         I_GeneralTransferManagerFactory.address.valueOf(),
@@ -193,7 +193,7 @@ async function registerAndVerifyByMR(factoryAdrress, owner, mr) {
 /// Deploy the TransferManagers
 
 export async function deployGTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_GeneralPermissionManagerFactory.address.valueOf(),
@@ -207,7 +207,7 @@ export async function deployGTMAndVerifyed(accountPolymath, MRProxyInstance, pol
 }
 
 export async function deployCountTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_CountTransferManagerFactory = await CountTransferManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_CountTransferManagerFactory = await CountTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_CountTransferManagerFactory.address.valueOf(),
@@ -220,7 +220,7 @@ export async function deployCountTMAndVerifyed(accountPolymath, MRProxyInstance,
 }
 
 export async function deployManualApprovalTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_ManualApprovalTransferManagerFactory = await ManualApprovalTransferManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_ManualApprovalTransferManagerFactory = await ManualApprovalTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_ManualApprovalTransferManagerFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -232,7 +232,7 @@ export async function deployManualApprovalTMAndVerifyed(accountPolymath, MRProxy
 }
 
 export async function deployPercentageTMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_PercentageTransferManagerFactory = await PercentageTransferManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_PercentageTransferManagerFactory = await PercentageTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_PercentageTransferManagerFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -244,7 +244,7 @@ export async function deployPercentageTMAndVerified(accountPolymath, MRProxyInst
 }
 
 export async function deployLockupVolumeRTMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_VolumeRestrictionTransferManagerFactory = await VolumeRestrictionTransferManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_VolumeRestrictionTransferManagerFactory = await VolumeRestrictionTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_VolumeRestrictionTransferManagerFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -256,7 +256,7 @@ export async function deployLockupVolumeRTMAndVerified(accountPolymath, MRProxyI
 }
 
 export async function deploySingleTradeVolumeRMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_SingleTradeVolumeRestrictionManagerFactory = await SingleTradeVolumeRestrictionManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_SingleTradeVolumeRestrictionManagerFactory = await SingleTradeVolumeRestrictionManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_SingleTradeVolumeRestrictionManagerFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -268,7 +268,7 @@ export async function deploySingleTradeVolumeRMAndVerified(accountPolymath, MRPr
 }
 
 export async function deployScheduleCheckpointAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_ScheduledCheckpointFactory = await ScheduledCheckpointFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_ScheduledCheckpointFactory = await ScheduledCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_ScheduledCheckpointFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -282,7 +282,7 @@ export async function deployScheduleCheckpointAndVerified(accountPolymath, MRPro
 /// Deploy the Permission Manager
 
 export async function deployGPMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_GeneralPermissionManagerFactory.address.valueOf(),
@@ -299,7 +299,7 @@ export async function deployGPMAndVerifyed(accountPolymath, MRProxyInstance, pol
 /// Deploy the STO Modules
 
 export async function deployDummySTOAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_DummySTOFactory = await DummySTOFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_DummySTOFactory = await DummySTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_DummySTOFactory.address.valueOf(),
@@ -311,7 +311,7 @@ export async function deployDummySTOAndVerifyed(accountPolymath, MRProxyInstance
 }
 
 export async function deployCappedSTOAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_CappedSTOFactory = await CappedSTOFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_CappedSTOFactory = await CappedSTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_CappedSTOFactory.address.valueOf(),
         "0x0000000000000000000000000000000000000000",
@@ -324,7 +324,7 @@ export async function deployCappedSTOAndVerifyed(accountPolymath, MRProxyInstanc
 }
 
 export async function deployPresaleSTOAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_PreSaleSTOFactory = await PreSaleSTOFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_PreSaleSTOFactory = await PreSaleSTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_PreSaleSTOFactory.address.valueOf(),
@@ -339,7 +339,7 @@ export async function deployPresaleSTOAndVerified(accountPolymath, MRProxyInstan
 export async function deployUSDTieredSTOAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
     I_USDTieredSTOProxyFactory = await USDTieredSTOProxyFactory.new({from: accountPolymath});
 
-    I_USDTieredSTOFactory = await USDTieredSTOFactory.new(polyToken, setupCost, 0, 0, I_USDTieredSTOProxyFactory.address, { from: accountPolymath });
+    I_USDTieredSTOFactory = await USDTieredSTOFactory.new(setupCost, 0, 0, I_USDTieredSTOProxyFactory.address, { from: accountPolymath });
 
     assert.notEqual(
         I_USDTieredSTOFactory.address.valueOf(),
@@ -355,7 +355,7 @@ export async function deployUSDTieredSTOAndVerified(accountPolymath, MRProxyInst
 /// Deploy the Dividend Modules
 
 export async function deployERC20DividendAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_ERC20DividendCheckpointFactory = await ERC20DividendCheckpointFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_ERC20DividendCheckpointFactory = await ERC20DividendCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_ERC20DividendCheckpointFactory.address.valueOf(),
@@ -367,7 +367,7 @@ export async function deployERC20DividendAndVerifyed(accountPolymath, MRProxyIns
 }
 
 export async function deployEtherDividendAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_EtherDividendCheckpointFactory = await EtherDividendCheckpointFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_EtherDividendCheckpointFactory = await EtherDividendCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_EtherDividendCheckpointFactory.address.valueOf(),
@@ -383,7 +383,7 @@ export async function deployEtherDividendAndVerifyed(accountPolymath, MRProxyIns
 /// Deploy the Burn Module
 
 export async function deployRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_TrackedRedemptionFactory = await TrackedRedemptionFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_TrackedRedemptionFactory = await TrackedRedemptionFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_TrackedRedemptionFactory.address.valueOf(),
@@ -397,7 +397,7 @@ export async function deployRedemptionAndVerifyed(accountPolymath, MRProxyInstan
 
 
 export async function deployMockRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_MockBurnFactory = await MockBurnFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_MockBurnFactory = await MockBurnFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_MockBurnFactory.address.valueOf(),
@@ -410,7 +410,7 @@ export async function deployMockRedemptionAndVerifyed(accountPolymath, MRProxyIn
 }
 
 export async function deployMockWrongTypeRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
-    I_MockWrongTypeBurnFactory = await MockWrongTypeFactory.new(polyToken, setupCost, 0, 0, { from: accountPolymath });
+    I_MockWrongTypeBurnFactory = await MockWrongTypeFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
         I_MockWrongTypeBurnFactory.address.valueOf(),

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -105,6 +105,8 @@ async function deployPolyRegistryAndPolyToken(account_polymath, token_owner) {
     I_PolyToken = await PolyTokenFaucet.new();
     await I_PolyToken.getTokens(10000 * Math.pow(10, 18), token_owner);
 
+    await I_PolymathRegistry.changeAddress("PolyToken", I_PolyToken.address, { from: account_polymath });
+
     return new Array(I_PolymathRegistry, I_PolyToken);
 }
 
@@ -177,7 +179,6 @@ async function setInPolymathRegistry(account_polymath) {
     await I_PolymathRegistry.changeAddress("FeatureRegistry", I_FeatureRegistry.address, { from: account_polymath });
     await I_PolymathRegistry.changeAddress("SecurityTokenRegistry", I_SecurityTokenRegistryProxy.address, { from: account_polymath });
     await I_MRProxied.updateFromRegistry({ from: account_polymath });
-    await I_STRProxied.updateFromRegistry({ from: account_polymath });
 }
 
 async function registerGTM(account_polymath) {

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -69,7 +69,7 @@ let I_MRProxied;
 // Initial fee for ticker registry and security token registry
 const initRegFee = web3.utils.toWei("250");
 
-const STRProxyParameters = ["address", "address", "uint256", "uint256", "address", "address"];
+const STRProxyParameters = ["address", "address", "uint256", "uint256", "address"];
 const MRProxyParameters = ["address", "address"];
 
 /// Function use to launch the polymath ecossystem.
@@ -163,7 +163,6 @@ async function deploySTR(account_polymath) {
         I_STFactory.address,
         initRegFee,
         initRegFee,
-        I_PolyToken.address,
         account_polymath
     ]);
     await I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, { from: account_polymath });

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -192,7 +192,7 @@ async function registerAndVerifyByMR(factoryAdrress, owner, mr) {
 
 /// Deploy the TransferManagers
 
-export async function deployGTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployGTMAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -206,7 +206,7 @@ export async function deployGTMAndVerifyed(accountPolymath, MRProxyInstance, pol
     return new Array(I_GeneralTransferManagerFactory);
 }
 
-export async function deployCountTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployCountTMAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_CountTransferManagerFactory = await CountTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -219,7 +219,7 @@ export async function deployCountTMAndVerifyed(accountPolymath, MRProxyInstance,
     return new Array(I_CountTransferManagerFactory);
 }
 
-export async function deployManualApprovalTMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployManualApprovalTMAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_ManualApprovalTransferManagerFactory = await ManualApprovalTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_ManualApprovalTransferManagerFactory.address.valueOf(),
@@ -231,7 +231,7 @@ export async function deployManualApprovalTMAndVerifyed(accountPolymath, MRProxy
     return new Array(I_ManualApprovalTransferManagerFactory);
 }
 
-export async function deployPercentageTMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployPercentageTMAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_PercentageTransferManagerFactory = await PercentageTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_PercentageTransferManagerFactory.address.valueOf(),
@@ -243,7 +243,7 @@ export async function deployPercentageTMAndVerified(accountPolymath, MRProxyInst
     return new Array(I_PercentageTransferManagerFactory);
 }
 
-export async function deployLockupVolumeRTMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployLockupVolumeRTMAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_VolumeRestrictionTransferManagerFactory = await VolumeRestrictionTransferManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_VolumeRestrictionTransferManagerFactory.address.valueOf(),
@@ -255,7 +255,7 @@ export async function deployLockupVolumeRTMAndVerified(accountPolymath, MRProxyI
     return new Array(I_VolumeRestrictionTransferManagerFactory);
 }
 
-export async function deploySingleTradeVolumeRMAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deploySingleTradeVolumeRMAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_SingleTradeVolumeRestrictionManagerFactory = await SingleTradeVolumeRestrictionManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_SingleTradeVolumeRestrictionManagerFactory.address.valueOf(),
@@ -267,7 +267,7 @@ export async function deploySingleTradeVolumeRMAndVerified(accountPolymath, MRPr
     return new Array(I_SingleTradeVolumeRestrictionManagerFactory);
 }
 
-export async function deployScheduleCheckpointAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployScheduleCheckpointAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_ScheduledCheckpointFactory = await ScheduledCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_ScheduledCheckpointFactory.address.valueOf(),
@@ -281,7 +281,7 @@ export async function deployScheduleCheckpointAndVerified(accountPolymath, MRPro
 
 /// Deploy the Permission Manager
 
-export async function deployGPMAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployGPMAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -298,7 +298,7 @@ export async function deployGPMAndVerifyed(accountPolymath, MRProxyInstance, pol
 
 /// Deploy the STO Modules
 
-export async function deployDummySTOAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployDummySTOAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_DummySTOFactory = await DummySTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -310,7 +310,7 @@ export async function deployDummySTOAndVerifyed(accountPolymath, MRProxyInstance
     return new Array(I_DummySTOFactory);
 }
 
-export async function deployCappedSTOAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployCappedSTOAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_CappedSTOFactory = await CappedSTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
     assert.notEqual(
         I_CappedSTOFactory.address.valueOf(),
@@ -323,7 +323,7 @@ export async function deployCappedSTOAndVerifyed(accountPolymath, MRProxyInstanc
 
 }
 
-export async function deployPresaleSTOAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployPresaleSTOAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_PreSaleSTOFactory = await PreSaleSTOFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -336,7 +336,7 @@ export async function deployPresaleSTOAndVerified(accountPolymath, MRProxyInstan
     return new Array(I_PreSaleSTOFactory);
 }
 
-export async function deployUSDTieredSTOAndVerified(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployUSDTieredSTOAndVerified(accountPolymath, MRProxyInstance, setupCost) {
     I_USDTieredSTOProxyFactory = await USDTieredSTOProxyFactory.new({from: accountPolymath});
 
     I_USDTieredSTOFactory = await USDTieredSTOFactory.new(setupCost, 0, 0, I_USDTieredSTOProxyFactory.address, { from: accountPolymath });
@@ -354,7 +354,7 @@ export async function deployUSDTieredSTOAndVerified(accountPolymath, MRProxyInst
 
 /// Deploy the Dividend Modules
 
-export async function deployERC20DividendAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployERC20DividendAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_ERC20DividendCheckpointFactory = await ERC20DividendCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -366,7 +366,7 @@ export async function deployERC20DividendAndVerifyed(accountPolymath, MRProxyIns
     return new Array(I_ERC20DividendCheckpointFactory);
 }
 
-export async function deployEtherDividendAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployEtherDividendAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_EtherDividendCheckpointFactory = await EtherDividendCheckpointFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -382,7 +382,7 @@ export async function deployEtherDividendAndVerifyed(accountPolymath, MRProxyIns
 
 /// Deploy the Burn Module
 
-export async function deployRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployRedemptionAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_TrackedRedemptionFactory = await TrackedRedemptionFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -396,7 +396,7 @@ export async function deployRedemptionAndVerifyed(accountPolymath, MRProxyInstan
 }
 
 
-export async function deployMockRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployMockRedemptionAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_MockBurnFactory = await MockBurnFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(
@@ -409,7 +409,7 @@ export async function deployMockRedemptionAndVerifyed(accountPolymath, MRProxyIn
     return new Array(I_MockBurnFactory);
 }
 
-export async function deployMockWrongTypeRedemptionAndVerifyed(accountPolymath, MRProxyInstance, polyToken, setupCost) {
+export async function deployMockWrongTypeRedemptionAndVerifyed(accountPolymath, MRProxyInstance, setupCost) {
     I_MockWrongTypeBurnFactory = await MockWrongTypeFactory.new(setupCost, 0, 0, { from: accountPolymath });
 
     assert.notEqual(

--- a/test/i_Issuance.js
+++ b/test/i_Issuance.js
@@ -168,7 +168,7 @@ contract("Issuance", accounts => {
             it("POLYMATH: Should successfully attach the STO factory with the security token", async () => {
                 // STEP 4: Deploy the CappedSTOFactory
 
-                I_CappedSTOFactory = await CappedSTOFactory.new(I_PolyToken.address, cappedSTOSetupCost, 0, 0, { from: account_polymath });
+                I_CappedSTOFactory = await CappedSTOFactory.new(cappedSTOSetupCost, 0, 0, { from: account_polymath });
 
                 assert.notEqual(
                     I_CappedSTOFactory.address.valueOf(),

--- a/test/i_Issuance.js
+++ b/test/i_Issuance.js
@@ -108,9 +108,9 @@ contract("Issuance", accounts => {
         ] = instances;
 
         // STEP 2: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 3: Deploy the CappedSTOFactory
-        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -104,13 +104,13 @@ contract("ManualApprovalTransferManager", accounts => {
         ] = instances;
 
         // STEP 2: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 3: Deploy the ManualApprovalTransferManagerFactory
-        [I_ManualApprovalTransferManagerFactory] = await deployManualApprovalTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_ManualApprovalTransferManagerFactory] = await deployManualApprovalTMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 4: Deploy the Paid ManualApprovalTransferManagerFactory
-        [P_ManualApprovalTransferManagerFactory] = await deployManualApprovalTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500", "ether"));
+        [P_ManualApprovalTransferManagerFactory] = await deployManualApprovalTMAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500", "ether"));
         // STEP 5: Deploy the CountTransferManagerFactory
-        [I_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_CountTransferManagerFactory] = await deployCountTMAndVerifyed(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`

--- a/test/k_module_registry.js
+++ b/test/k_module_registry.js
@@ -260,13 +260,13 @@ contract("ModuleRegistry", accounts => {
             });
 
             it("Should fail in registering the module-- type = 0", async () => {
-                I_MockFactory = await MockFactory.new(I_PolyToken.address, 0, 0, 0, { from: account_polymath });
+                I_MockFactory = await MockFactory.new(0, 0, 0, { from: account_polymath });
 
                 catchRevert(I_MRProxied.registerModule(I_MockFactory.address, { from: account_polymath }));
             });
 
             it("Should fail to register the new module because msg.sender is not the owner of the module", async() => {
-                I_CappedSTOFactory3 = await CappedSTOFactory.new(I_PolyToken.address, 0, 0, 0, { from: account_temp });
+                I_CappedSTOFactory3 = await CappedSTOFactory.new(0, 0, 0, { from: account_temp });
                 catchRevert(
                     I_MRProxied.registerModule(I_CappedSTOFactory3.address, { from: token_owner })
                 );
@@ -292,7 +292,7 @@ contract("ModuleRegistry", accounts => {
             });
 
             it("Should successfully verify the module -- false", async () => {
-                I_CappedSTOFactory1 = await CappedSTOFactory.new(I_PolyToken.address, 0, 0, 0, { from: account_polymath });
+                I_CappedSTOFactory1 = await CappedSTOFactory.new(0, 0, 0, { from: account_polymath });
                 await I_MRProxied.registerModule(I_CappedSTOFactory1.address, { from: account_polymath });
                 let tx = await I_MRProxied.verifyModule(I_CappedSTOFactory1.address, false, { from: account_polymath });
                 assert.equal(tx.logs[0].args._moduleFactory, I_CappedSTOFactory1.address, "Failed in verifying the module");
@@ -323,7 +323,7 @@ contract("ModuleRegistry", accounts => {
             });
 
             it("Should fail to register module because custom modules not allowed", async () => {
-                I_CappedSTOFactory2 = await CappedSTOFactory.new(I_PolyToken.address, 0, 0, 0, { from: token_owner });
+                I_CappedSTOFactory2 = await CappedSTOFactory.new(0, 0, 0, { from: token_owner });
 
                 assert.notEqual(
                     I_CappedSTOFactory2.address.valueOf(),
@@ -376,7 +376,7 @@ contract("ModuleRegistry", accounts => {
             })
 
             it("Should successfully add verified module", async () => {
-                I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(I_PolyToken.address, 0, 0, 0, {
+                I_GeneralPermissionManagerFactory = await GeneralPermissionManagerFactory.new(0, 0, 0, {
                     from: account_polymath
                 });
                 await I_MRProxied.registerModule(I_GeneralPermissionManagerFactory.address, { from: account_polymath });
@@ -386,7 +386,7 @@ contract("ModuleRegistry", accounts => {
             });
 
             it("Should failed in adding the TestSTOFactory module because not compatible with the current protocol version --lower", async () => {
-                I_TestSTOFactory = await TestSTOFactory.new(I_PolyToken.address, 0, 0, 0, { from: account_polymath });
+                I_TestSTOFactory = await TestSTOFactory.new(0, 0, 0, { from: account_polymath });
                 await I_MRProxied.registerModule(I_TestSTOFactory.address, { from: account_polymath });
                 await I_MRProxied.verifyModule(I_TestSTOFactory.address, true, { from: account_polymath });
                 // Taking the snapshot the revert the changes from here

--- a/test/l_percentage_transfer_manager.js
+++ b/test/l_percentage_transfer_manager.js
@@ -113,13 +113,13 @@ contract("PercentageTransferManager", accounts => {
         ] = instances;
 
         // STEP 2: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
 
         // STEP 3(a): Deploy the PercentageTransferManager
-        [I_PercentageTransferManagerFactory] = await deployPercentageTMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_PercentageTransferManagerFactory] = await deployPercentageTMAndVerified(account_polymath, I_MRProxied, 0);
 
         // STEP 4(b): Deploy the PercentageTransferManager
-        [P_PercentageTransferManagerFactory] = await deployPercentageTMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500", "ether"));
+        [P_PercentageTransferManagerFactory] = await deployPercentageTMAndVerified(account_polymath, I_MRProxied, web3.utils.toWei("500", "ether"));
     
         // Printing all the contract addresses
         console.log(`

--- a/test/m_presale_sto.js
+++ b/test/m_presale_sto.js
@@ -100,9 +100,9 @@ contract("PreSaleSTO", accounts => {
         ] = instances;
 
         // STEP 4: Deploy the PreSaleSTOFactory
-        [I_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, 0);
         // STEP 5: Deploy the paid PresaleSTOFactory
-        [P_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [P_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -262,8 +262,17 @@ contract("SecurityTokenRegistry", accounts => {
                 from: account_polymath
             });
             I_STRProxied = SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
+        });
 
-            await I_STRProxied.updateFromRegistry({ from: account_polymath });
+        describe("Test case for the upgradeFromregistry", async () => {
+            it("Should successfully update the registry contract address -- failed because of bad owner", async () => {
+                await catchRevert(I_STRProxied.updateFromRegistry({ from: account_temp }));
+            });
+
+            it("Should successfully update the registry contract addresses", async () => {
+                await I_STRProxied.updateFromRegistry({ from: account_polymath });
+                assert.equal(await I_STRProxied.getAddressValues.call(web3.utils.soliditySha3("polyToken")), I_PolyToken.address);
+            });
         });
     });
 
@@ -930,29 +939,6 @@ contract("SecurityTokenRegistry", accounts => {
 
             // Verify the successful generation of the security token
             assert.equal(tx.logs[2].args._ticker, "POLY", "SecurityToken doesn't get deployed");
-        });
-    });
-
-    describe("Test case for the update poly token", async () => {
-        it("Should change the polytoken address -- failed because of bad owner", async () => {
-            catchRevert(
-                I_STRProxied.updatePolyTokenAddress(dummy_token, { from: account_temp }),
-                "tx revert -> failed because of bad owner"
-            );
-        });
-
-        it("Should change the polytoken address -- failed because of 0x address", async () => {
-            catchRevert(
-                I_STRProxied.updatePolyTokenAddress("0x0000000000000000000000000000000000000000000", { from: account_polymath }),
-                "tx revert -> failed because 0x address"
-            );
-        });
-
-        it("Should successfully change the polytoken address", async () => {
-            let _id = await takeSnapshot();
-            await I_STRProxied.updatePolyTokenAddress(dummy_token, { from: account_polymath });
-            assert.equal(await I_STRProxied.getAddressValues.call(web3.utils.soliditySha3("polyToken")), dummy_token);
-            await revertToSnapshot(_id);
         });
     });
 

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -263,17 +263,6 @@ contract("SecurityTokenRegistry", accounts => {
             });
             I_STRProxied = SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
         });
-
-        describe("Test case for the upgradeFromregistry", async () => {
-            it("Should successfully update the registry contract address -- failed because of bad owner", async () => {
-                await catchRevert(I_STRProxied.updateFromRegistry({ from: account_temp }));
-            });
-
-            it("Should successfully update the registry contract addresses", async () => {
-                await I_STRProxied.updateFromRegistry({ from: account_polymath });
-                assert.equal(await I_STRProxied.getAddressValues.call(web3.utils.soliditySha3("polyToken")), I_PolyToken.address);
-            });
-        });
     });
 
     describe(" Test cases of the registerTicker", async () => {

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -119,7 +119,7 @@ contract("SecurityTokenRegistry", accounts => {
 
         // STEP 8: Deploy the CappedSTOFactory
 
-        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, 0);
         // Step 9: Deploy the SecurityTokenRegistry
 
         I_SecurityTokenRegistry = await SecurityTokenRegistry.new({ from: account_polymath });

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -286,6 +286,8 @@ contract("SecurityTokenRegistry", accounts => {
                 from: account_polymath
             });
             I_STRProxied = SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
+
+            await I_STRProxied.updateFromRegistry({ from: account_polymath });
         });
     });
 

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -82,7 +82,7 @@ contract("SecurityTokenRegistry", accounts => {
     const initRegFee = web3.utils.toWei("250");
     const newRegFee = web3.utils.toWei("300");
 
-    const STRProxyParameters = ["address", "address", "uint256", "uint256", "address", "address"];
+    const STRProxyParameters = ["address", "address", "uint256", "uint256", "address"];
     const STOParameters = ["uint256", "uint256", "uint256", "string"];
 
     // Capped STO details
@@ -160,7 +160,6 @@ contract("SecurityTokenRegistry", accounts => {
                 I_STFactory.address,
                 initRegFee,
                 initRegFee,
-                I_PolyToken.address,
                 account_polymath
             ]);
             catchRevert(
@@ -177,7 +176,6 @@ contract("SecurityTokenRegistry", accounts => {
                 address_zero,
                 initRegFee,
                 initRegFee,
-                I_PolyToken.address,
                 account_polymath
             ]);
             catchRevert(
@@ -194,7 +192,6 @@ contract("SecurityTokenRegistry", accounts => {
                 I_STFactory.address,
                 0,
                 initRegFee,
-                I_PolyToken.address,
                 account_polymath
             ]);
             catchRevert(
@@ -211,7 +208,6 @@ contract("SecurityTokenRegistry", accounts => {
                 I_STFactory.address,
                 initRegFee,
                 0,
-                I_PolyToken.address,
                 account_polymath
             ]);
             catchRevert(
@@ -222,30 +218,12 @@ contract("SecurityTokenRegistry", accounts => {
             );
         });
 
-        it("Should successfully update the implementation address -- fail because PolyToken address is 0x", async () => {
-            let bytesProxy = encodeProxyCall(STRProxyParameters, [
-                I_PolymathRegistry.address,
-                I_STFactory.address,
-                initRegFee,
-                initRegFee,
-                address_zero,
-                account_polymath
-            ]);
-            catchRevert(
-                I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {
-                    from: account_polymath
-                }),
-                "tx-> revert because PolyToken address is 0x"
-            );
-        });
-
         it("Should successfully update the implementation address -- fail because owner address is 0x", async () => {
             let bytesProxy = encodeProxyCall(STRProxyParameters, [
                 I_PolymathRegistry.address,
                 I_STFactory.address,
                 initRegFee,
                 initRegFee,
-                I_PolyToken.address,
                 address_zero
             ]);
             catchRevert(
@@ -262,7 +240,6 @@ contract("SecurityTokenRegistry", accounts => {
                 address_zero,
                 0,
                 0,
-                address_zero,
                 address_zero
             ]);
             catchRevert(
@@ -279,7 +256,6 @@ contract("SecurityTokenRegistry", accounts => {
                 I_STFactory.address,
                 initRegFee,
                 initRegFee,
-                I_PolyToken.address,
                 account_polymath
             ]);
             await I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {
@@ -322,7 +298,6 @@ contract("SecurityTokenRegistry", accounts => {
                     I_STFactory.address,
                     initRegFee,
                     initRegFee,
-                    I_PolyToken.address,
                     account_polymath
                 ),
                 "tx revert -> Can't call the intialize function again"

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -133,9 +133,9 @@ contract("SecurityToken", accounts => {
         ] = instances;
 
         // STEP 2: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
         // STEP 3: Deploy the CappedSTOFactory
-        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, cappedSTOSetupCost);
+        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, cappedSTOSetupCost);
 
         // Printing all the contract addresses
         console.log(`
@@ -420,9 +420,9 @@ contract("SecurityToken", accounts => {
             let FactoryInstances;
             let GPMAddress = new Array();
 
-            [D_GPM] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-            [D_GPM_1] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-            [D_GPM_2] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+            [D_GPM] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
+            [D_GPM_1] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
+            [D_GPM_2] = await deployGPMAndVerifyed(account_polymath, I_MRProxied, 0);
             FactoryInstances = [D_GPM, D_GPM_1, D_GPM_2];
             // Adding module in the ST
             for (let i = 0; i < FactoryInstances.length; i++) {
@@ -950,7 +950,7 @@ contract("SecurityToken", accounts => {
     describe("Test cases for the Mock TrackedRedeemption", async() => {
 
         it("Should add the tracked redeemption module successfully", async() => {
-            [I_MockRedemptionManagerFactory] = await deployMockRedemptionAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+            [I_MockRedemptionManagerFactory] = await deployMockRedemptionAndVerifyed(account_polymath, I_MRProxied, 0);
             let tx = await I_SecurityToken.addModule(I_MockRedemptionManagerFactory.address, "", 0, 0, {from: token_owner });
             assert.equal(tx.logs[2].args._types[0], burnKey, "fail in adding the burn manager");
             I_MockRedemptionManager = MockRedemptionManager.at(tx.logs[2].args._module);
@@ -993,7 +993,7 @@ contract("SecurityToken", accounts => {
         })
 
         it("Should successfully fail in calling the burn functions", async() => {
-            [I_MockRedemptionManagerFactory] = await deployMockWrongTypeRedemptionAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+            [I_MockRedemptionManagerFactory] = await deployMockWrongTypeRedemptionAndVerifyed(account_polymath, I_MRProxied, 0);
             let tx = await I_SecurityToken.addModule(I_MockRedemptionManagerFactory.address, "", 0, 0, {from: token_owner });
             I_MockRedemptionManager = MockRedemptionManager.at(tx.logs[2].args._module);
 

--- a/test/p_usd_tiered_sto.js
+++ b/test/p_usd_tiered_sto.js
@@ -225,11 +225,11 @@ contract("USDTieredSTO", accounts => {
         
         I_DaiToken = await PolyTokenFaucet.new({from: POLYMATH});
         // STEP 4: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(POLYMATH, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(POLYMATH, I_MRProxied, 0);
 
         // STEP 5: Deploy the USDTieredSTOFactory
-        [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
-        [P_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+        [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, STOSetupCost);
+        [P_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, web3.utils.toWei("500"));
         // Step 12: Deploy & Register Mock Oracles
         I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
         I_POLYOracle = await MockOracle.new(I_PolyToken.address, "POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY

--- a/test/p_usd_tiered_sto.js
+++ b/test/p_usd_tiered_sto.js
@@ -231,8 +231,8 @@ contract("USDTieredSTO", accounts => {
         [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
         [P_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
         // Step 12: Deploy & Register Mock Oracles
-        I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
-        I_POLYOracle = await MockOracle.new(I_PolyToken.address, "POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
+        I_USDOracle = await MockOracle.new("ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
+        I_POLYOracle = await MockOracle.new("POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
         await I_PolymathRegistry.changeAddress("EthUsdOracle", I_USDOracle.address, { from: POLYMATH });
         await I_PolymathRegistry.changeAddress("PolyUsdOracle", I_POLYOracle.address, { from: POLYMATH });
 

--- a/test/p_usd_tiered_sto.js
+++ b/test/p_usd_tiered_sto.js
@@ -231,8 +231,8 @@ contract("USDTieredSTO", accounts => {
         [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
         [P_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
         // Step 12: Deploy & Register Mock Oracles
-        I_USDOracle = await MockOracle.new("ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
-        I_POLYOracle = await MockOracle.new("POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
+        I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
+        I_POLYOracle = await MockOracle.new(I_PolyToken.address, "POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
         await I_PolymathRegistry.changeAddress("EthUsdOracle", I_USDOracle.address, { from: POLYMATH });
         await I_PolymathRegistry.changeAddress("PolyUsdOracle", I_POLYOracle.address, { from: POLYMATH });
 

--- a/test/q_usd_tiered_sto_sim.js
+++ b/test/q_usd_tiered_sto_sim.js
@@ -202,8 +202,8 @@ contract("USDTieredSTO Sim", accounts => {
        [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
 
         // Step 12: Deploy & Register Mock Oracles
-        I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
-        I_POLYOracle = await MockOracle.new(I_PolyToken.address, "POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
+        I_USDOracle = await MockOracle.new("ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
+        I_POLYOracle = await MockOracle.new("POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
         await I_PolymathRegistry.changeAddress("EthUsdOracle", I_USDOracle.address, { from: POLYMATH });
         await I_PolymathRegistry.changeAddress("PolyUsdOracle", I_POLYOracle.address, { from: POLYMATH });
 

--- a/test/q_usd_tiered_sto_sim.js
+++ b/test/q_usd_tiered_sto_sim.js
@@ -202,8 +202,8 @@ contract("USDTieredSTO Sim", accounts => {
        [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
 
         // Step 12: Deploy & Register Mock Oracles
-        I_USDOracle = await MockOracle.new("ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
-        I_POLYOracle = await MockOracle.new("POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
+        I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY
+        I_POLYOracle = await MockOracle.new(I_PolyToken.address, "POLY", "USD", USDPOLY, { from: POLYMATH }); // 25 cents per POLY
         await I_PolymathRegistry.changeAddress("EthUsdOracle", I_USDOracle.address, { from: POLYMATH });
         await I_PolymathRegistry.changeAddress("PolyUsdOracle", I_POLYOracle.address, { from: POLYMATH });
 

--- a/test/q_usd_tiered_sto_sim.js
+++ b/test/q_usd_tiered_sto_sim.js
@@ -199,7 +199,7 @@ contract("USDTieredSTO Sim", accounts => {
        I_DaiToken = await PolyTokenFaucet.new({from: POLYMATH});
 
        // STEP 5: Deploy the USDTieredSTOFactory
-       [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
+       [I_USDTieredSTOFactory] = await deployUSDTieredSTOAndVerified(POLYMATH, I_MRProxied, STOSetupCost);
 
         // Step 12: Deploy & Register Mock Oracles
         I_USDOracle = await MockOracle.new(0, "ETH", "USD", USDETH, { from: POLYMATH }); // 500 dollars per POLY

--- a/test/r_concurrent_STO.js
+++ b/test/r_concurrent_STO.js
@@ -97,9 +97,9 @@ contract("Concurrent STO", accounts => {
       
         // STEP 2: Deploy the STO Factories
 
-        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, STOSetupCost);
-        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, STOSetupCost);
-        [I_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, STOSetupCost);
+        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(account_polymath, I_MRProxied, STOSetupCost);
+        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, STOSetupCost);
+        [I_PreSaleSTOFactory] = await deployPresaleSTOAndVerified(account_polymath, I_MRProxied, STOSetupCost);
 
         // Printing all the contract addresses
         console.log(`

--- a/test/s_v130_to_v140_upgrade.js
+++ b/test/s_v130_to_v140_upgrade.js
@@ -219,7 +219,6 @@ contract("Upgrade from v1.3.0 to v1.4.0", accounts => {
         it("Should successfully deploy USDTieredSTOFactory", async () => {
             I_USDTieredSTOProxyFactory = await USDTieredSTOProxyFactory.new();
             I_USDTieredSTOFactory = await USDTieredSTOFactory.new(
-                I_PolyToken.address,
                 STOSetupCost,
                 0,
                 0,

--- a/test/s_v130_to_v140_upgrade.js
+++ b/test/s_v130_to_v140_upgrade.js
@@ -118,10 +118,10 @@ contract("Upgrade from v1.3.0 to v1.4.0", accounts => {
         ] = instances;
 
         // STEP 4: Deploy the GeneralDelegateManagerFactory
-        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(POLYMATH, I_MRProxied, I_PolyToken.address, 0);
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(POLYMATH, I_MRProxied, 0);
 
         // STEP 5: Deploy the CappedSTOFactory
-        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(POLYMATH, I_MRProxied, I_PolyToken.address, STOSetupCost);
+        [I_CappedSTOFactory] = await deployCappedSTOAndVerifyed(POLYMATH, I_MRProxied, STOSetupCost);
 
         // Step 12: Mint tokens to ISSUERs
         await I_PolyToken.getTokens(REGFEE * 2, ISSUER1);

--- a/test/s_v130_to_v140_upgrade.js
+++ b/test/s_v130_to_v140_upgrade.js
@@ -247,7 +247,7 @@ contract("Upgrade from v1.3.0 to v1.4.0", accounts => {
     describe("CappedSTOFactory deploy", async () => {
         // Step 1: Deploy new CappedSTOFactory
         it("Should successfully deploy CappedSTOFactory", async () => {
-            I_UpgradedCappedSTOFactory = await CappedSTOFactory.new(I_PolyToken.address, STOSetupCost, 0, 0, { from: POLYMATH });
+            I_UpgradedCappedSTOFactory = await CappedSTOFactory.new(STOSetupCost, 0, 0, { from: POLYMATH });
             assert.notEqual(
                 I_UpgradedCappedSTOFactory.address.valueOf(),
                 address_zero,
@@ -277,7 +277,7 @@ contract("Upgrade from v1.3.0 to v1.4.0", accounts => {
     describe("ManualApprovalTransferManagerFactory deploy", async () => {
         // Step 1: Deploy new ManualApprovalTransferManager
         it("Should successfully deploy ManualApprovalTransferManagerFactory", async () => {
-            I_ManualApprovalTransferManagerFactory = await ManualApprovalTransferManagerFactory.new(I_PolyToken.address, 0, 0, 0, {
+            I_ManualApprovalTransferManagerFactory = await ManualApprovalTransferManagerFactory.new(0, 0, 0, {
                 from: POLYMATH
             });
             assert.notEqual(

--- a/test/t_security_token_registry_proxy.js
+++ b/test/t_security_token_registry_proxy.js
@@ -46,7 +46,7 @@ contract("SecurityTokenRegistryProxy", accounts => {
     const decimals = 18;
 
     const transferManagerKey = 2;
-    const STRProxyParameters = ["address", "address", "uint256", "uint256", "address", "address"];
+    const STRProxyParameters = ["address", "address", "uint256", "uint256", "address"];
 
     async function readStorage(contractAddress, slot) {
         return await web3.eth.getStorageAt(contractAddress, slot);
@@ -120,6 +120,8 @@ contract("SecurityTokenRegistryProxy", accounts => {
                 "1.0.0"
             );
             I_STRProxied = await SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
+
+            await I_STRProxied.updateFromRegistry({ from: account_polymath });
         });
 
         it("Verify the initialize data", async () => {

--- a/test/t_security_token_registry_proxy.js
+++ b/test/t_security_token_registry_proxy.js
@@ -120,8 +120,6 @@ contract("SecurityTokenRegistryProxy", accounts => {
                 "1.0.0"
             );
             I_STRProxied = await SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
-
-            await I_STRProxied.updateFromRegistry({ from: account_polymath });
         });
 
         it("Verify the initialize data", async () => {

--- a/test/t_security_token_registry_proxy.js
+++ b/test/t_security_token_registry_proxy.js
@@ -105,7 +105,6 @@ contract("SecurityTokenRegistryProxy", accounts => {
                 I_STFactory.address,
                 initRegFee,
                 initRegFee,
-                I_PolyToken.address,
                 account_polymath
             ]);
             await I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {

--- a/test/u_module_registry_proxy.js
+++ b/test/u_module_registry_proxy.js
@@ -122,7 +122,7 @@ contract("ModuleRegistryProxy", accounts => {
             await I_MRProxied.updateFromRegistry({ from: account_polymath });
             // STEP 4: Deploy the GeneralTransferManagerFactory
 
-            I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(I_PolyToken.address, 0, 0, 0, {
+            I_GeneralTransferManagerFactory = await GeneralTransferManagerFactory.new(0, 0, 0, {
                 from: account_polymath
             });
 
@@ -160,7 +160,7 @@ contract("ModuleRegistryProxy", accounts => {
 
     describe("Feed some data in storage", async () => {
         it("Register and verify the new module", async () => {
-            I_GeneralPermissionManagerfactory = await GeneralPermissionManagerFactory.new(I_PolyToken.address, 0, 0, 0, {
+            I_GeneralPermissionManagerfactory = await GeneralPermissionManagerFactory.new(0, 0, 0, {
                 from: account_polymath
             });
 

--- a/test/v_tracked_redemptions.js
+++ b/test/v_tracked_redemptions.js
@@ -104,8 +104,8 @@ contract("TrackedRedemption", accounts => {
 
       
         // STEP 4: Deploy the TrackedRedemption
-        [I_TrackedRedemptionFactory] = await deployRedemptionAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-        [P_TrackedRedemptionFactory] = await deployRedemptionAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+        [I_TrackedRedemptionFactory] = await deployRedemptionAndVerifyed(account_polymath, I_MRProxied, 0);
+        [P_TrackedRedemptionFactory] = await deployRedemptionAndVerifyed(account_polymath, I_MRProxied, web3.utils.toWei("500"));
 
         // Printing all the contract addresses
         console.log(`

--- a/test/w_lockup_volume_restriction_transfer_manager.js
+++ b/test/w_lockup_volume_restriction_transfer_manager.js
@@ -95,9 +95,9 @@ contract('LockupVolumeRestrictionTransferManager', accounts => {
         ] = instances;
 
         // STEP 4(c): Deploy the VolumeRestrictionTransferManager
-        [I_VolumeRestrictionTransferManagerFactory] = await deployLockupVolumeRTMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_VolumeRestrictionTransferManagerFactory] = await deployLockupVolumeRTMAndVerified(account_polymath, I_MRProxied, 0);
         // STEP 4(d): Deploy the VolumeRestrictionTransferManager
-        [P_VolumeRestrictionTransferManagerFactory] = await deployLockupVolumeRTMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+        [P_VolumeRestrictionTransferManagerFactory] = await deployLockupVolumeRTMAndVerified(account_polymath, I_MRProxied, web3.utils.toWei("500"));
 
         // Printing all the contract addresses
         console.log(`

--- a/test/x_single_trade_volume_restriction.js
+++ b/test/x_single_trade_volume_restriction.js
@@ -105,8 +105,8 @@ contract('SingleTradeVolumeRestrictionManager', accounts => {
     ] = instances;
 
     // STEP 4: Deploy the SingleTradeVolumeRestrictionManagerFactory
-    [I_SingleTradeVolumeRestrictionManagerFactory] = await deploySingleTradeVolumeRMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
-    [P_SingleTradeVolumeRestrictionManagerFactory] = await deploySingleTradeVolumeRMAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, web3.utils.toWei("500"));
+    [I_SingleTradeVolumeRestrictionManagerFactory] = await deploySingleTradeVolumeRMAndVerified(account_polymath, I_MRProxied, 0);
+    [P_SingleTradeVolumeRestrictionManagerFactory] = await deploySingleTradeVolumeRMAndVerified(account_polymath, I_MRProxied, web3.utils.toWei("500"));
   
   });
 

--- a/test/y_scheduled_checkpoints.js
+++ b/test/y_scheduled_checkpoints.js
@@ -93,7 +93,7 @@ contract('ScheduledCheckpoint', accounts => {
         ] = instances;
 
         // STEP 2: Deploy the ScheduleCheckpointModule
-        [I_ScheduledCheckpointFactory] = await deployScheduleCheckpointAndVerified(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+        [I_ScheduledCheckpointFactory] = await deployScheduleCheckpointAndVerified(account_polymath, I_MRProxied, 0);
 
         // Printing all the contract addresses
         console.log(`


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our Submission guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
Instead of manually entering the PolyToken on the deployment of each contract, have them fetch it from the PMRegistry.


### Does this PR introduce a breaking change?
1. Removed _polyAddress parameter from constructors of all modules and module factories.
2. Removed _polyToken parameter from SecurityTokenRegistry.initialize
3. Removed SecurityTokenRegistry.updatePolyTokenAddress



### Any Other information:
