### PR TITLE
Adding Circle CI to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,9 @@ jobs:
       - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
-      - run: npm run coverage
+      - run: 
+          command: npm run coverage
+          no_output_timeout: 1h
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,8 @@ workflows:
   commit:
     jobs:
       - test
-      - coverage
+      - coverage:
+          type: approval
   daily-builds:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: yarn
+      - run: npm i truffle -g
       - run: node --version
       - run: truffle version
       - run: npm run test
@@ -23,6 +24,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: yarn
+      - run: npm i truffle -g
       - run: node --version
       - run: truffle version
       - run: npm run docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - store_test_results:
+          path: test-results
   coverage:
     docker:
       - image: circleci/node:8
@@ -48,6 +50,9 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - store_test_results:
+          path: test-results
+
   docs:
     docker:
       - image: circleci/node:8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: yarn
+      - run: yarn install
       - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: yarn
+      - run: yarn install
       - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
@@ -39,7 +39,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: yarn
+      - run: yarn install
       - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: yarn
+      - run: yarn install
       - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
@@ -68,7 +68,5 @@ workflows:
   version: 2
   build-test-coverage-docs:
     jobs:
-      - build
       - test
       - coverage
-      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: yarn
-      - run: npm i truffle -g
+      - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
       - run: npm run test
@@ -24,7 +24,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: yarn
-      - run: npm i truffle -g
+      - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
       - run: npm run docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+        - yarn 
+        - node --version
+        - truffle version
+        - npm run test
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+  docs:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: 
+        - yarn
+        - npm run docs
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+workflows:
+  version: 2
+  test_and_docs:
+    jobs:
+      - test
+      - docs
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
             - node_modules
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: ./test-results/mocha/results.xml
   coverage:
     docker:
       - image: circleci/node:8
@@ -50,6 +52,8 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - store_artifacts:
+          path: ./coverage/lcov.info
   docs:
     docker:
       - image: circleci/node:8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ workflows:
     jobs:
       - coverage
   docs:
-    filters:
-      branches:
-        only:
-          - master
     jobs:
-      - docs
+      - docs:
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
-    parallelism: 4
+    parallelism: 3
     steps:
       - checkout
       - restore_cache:
@@ -76,8 +76,7 @@ workflows:
   commit:
     jobs:
       - test
-      - coverage:
-          type: approval
+      - coverage
   daily-builds:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ workflows:
     jobs:
       - build
       - test
+      - coverage
   daily-coverage:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,20 @@ jobs:
             - node_modules
 workflows:
   version: 2
-  build-test-coverage-docs:
+  commit:
     jobs:
+      - build
       - test
+  daily-coverage:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+    jobs:
       - coverage
+  docs:
+    filters:
+      branches:
+        only:
+          - master
+    jobs:
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,10 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-        - yarn 
-        - node --version
-        - truffle version
-        - npm run test
+      - run: yarn
+      - run: node --version
+      - run: truffle version
+      - run: npm run test
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
@@ -23,9 +22,10 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: 
-        - yarn
-        - npm run docs
+      - run: yarn
+      - run: node --version
+      - run: truffle version
+      - run: npm run docs
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,26 @@
 version: 2
 jobs:
+  build:
+    docker:
+      - image: circleci/node:8
+    parallelism: 4
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: yarn
+      - run: sudo npm i truffle -g
+      - run: node --version
+      - run: truffle version
+      - run: truffle compile
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
   test:
     docker:
       - image: circleci/node:8
+    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -12,6 +30,23 @@ jobs:
       - run: node --version
       - run: truffle version
       - run: npm run test
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+  coverage:
+    docker:
+      - image: circleci/node:8
+    parallelism: 4
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: yarn
+      - run: sudo npm i truffle -g
+      - run: node --version
+      - run: truffle version
+      - run: npm run coverage
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
@@ -34,8 +69,16 @@ jobs:
             - node_modules
 workflows:
   version: 2
-  test_and_docs:
+  build-test-coverage-docs:
     jobs:
-      - test
-      - docs
+      - build
+      - test:
+          - requires:
+              - build
+      - coverage:
+          - requires:
+              - test
+      - docs:
+          - requires:
+              - coverage
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
-    parallelism: 3
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:
@@ -75,7 +75,6 @@ workflows:
   version: 2
   commit:
     jobs:
-      - test
       - coverage
   daily-builds:
     triggers:
@@ -85,10 +84,10 @@ workflows:
             branches:
               only:
                 - master
-                - development-2.1.0
-                - development-3.0.0
+                - dev-2.1.0
+                - dev-2.2.0
+                - dev-3.0.0
     jobs:
-      - test
       - coverage
   docs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
-    parallelism: 2
+    parallelism: 3
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,6 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - store_test_results:
-          path: test-results
-
   docs:
     docker:
       - image: circleci/node:8
@@ -73,9 +70,9 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
       - test
-  daily-coverage:
+      - coverage
+  daily-builds:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -86,6 +83,7 @@ workflows:
                 - development-2.1.0
                 - development-3.0.0
     jobs:
+      - test
       - coverage
   docs:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,12 @@ workflows:
     jobs:
       - build
       - test:
-          - requires:
-              - build
+          requires:
+            - build
       - coverage:
-          - requires:
-              - test
+          requires:
+            - test
       - docs:
-          - requires:
-              - coverage
+          requires:
+            - coverage
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ workflows:
     triggers:
       - schedule:
           cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - development-2.1.0
+                - development-3.0.0
     jobs:
       - coverage
   docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
-    parallelism: 3
+    parallelism: 4
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:8
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -20,7 +19,6 @@ jobs:
   test:
     docker:
       - image: circleci/node:8
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -37,7 +35,6 @@ jobs:
   coverage:
     docker:
       - image: circleci/node:8
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -72,13 +69,6 @@ workflows:
   build-test-coverage-docs:
     jobs:
       - build
-      - test:
-          requires:
-            - build
-      - coverage:
-          requires:
-            - test
-      - docs:
-          requires:
-            - coverage
-      
+      - test
+      - coverage
+      - docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ workflows:
     jobs:
       - build
       - test
-      - coverage
   daily-coverage:
     triggers:
       - schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ bridge.log
 .node-xml*
 .solcover.js.bk
 allFiredEvents
+extract/
+extract.py
+extract.zip
+/test-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,11 @@ node_js:
 cache:
   directories:
   - node_modules
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: 'TASK=docs'
 jobs:
   include:
-    - stage: Tests and Coverage
-      after_install: wget -O node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+    - stage: test
       before_script: truffle version
       script: npm run test
-    - stage: Docs
-      env: 'TASK=docs'
-      before_install: 
-        - echo -ne '\n' | sudo apt-add-repository -y ppa:hvr/z3
-        - sudo apt-get -y update
-        - sudo apt-get -y install libz3-dev 
-      before_script: wget -O node_modules/solidity-docgen/lib/index.js https://raw.githubusercontent.com/maxsam4/solidity-docgen/buffer-size/lib/index.js
-      script: npm run docs
 notifications:
   slack:
     secure: W4FZSabLrzF74f317hutolEHnlq2GBlQxU6b85L5XymrjgLEhlgE16c5Qz7Emoyt6le6PXL+sfG2ujJc3XYys/6hppgrHSAasuJnKCdQNpmMZ9BNyMs6WGkmB3enIf3K/FLXb26AQdwpQdIXuOeJUTf879u+YoiZV0eZH8d3+fsIOyovq9N6X5pKOpDM9iT8gGB4t7fie7xf51s+iUaHxyO9G7jDginZ4rBXHcU7mxCub9z+Z1H8+kCTnPWaF+KKVEXx4Z0nI3+urboD7E4OIP02LwrThQls2CppA3X0EoesTcdvj/HLErY/JvsXIFiFEEHZzB1Wi+k2TiOeLcYwEuHIVij+HPxxlJNX/j8uy01Uk8s4rd+0EhvfdKHJqUKqxH4YN2npcKfHEss7bU3y7dUinXQfYShW5ZewHdvc7pnnxBTfhvmdi64HdNrXAPq+s1rhciH7MmnU+tsm4lhrpr+FBuHzUMA9fOCr7b0SQytZEgWpiUls88gdbh3yG8TjyZxmZJGx09cwEP0q7VoH0UwFh7mIu5XmYdd5tWUhavTiO7YV8cUPn7MvwMsTltB3YBpF/fB26L7ka8zBhCsjm9prW6SVYU/dyO3m91VeZtO/zJFHRDA6Q58JGVW2rgzO39z193qC1EGRXqTie96VwAAtNg8+hRb+bI/CWDVzSPc=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/maxsam4/polymath-core.svg?style=svg)](https://circleci.com/gh/maxsam4/polymath-core)
+[![Build Status](https://travis-ci.org/PolymathNetwork/polymath-core.svg?branch=master)](https://travis-ci.org/PolymathNetwork/polymath-core)
 [![Coverage Status](https://coveralls.io/repos/github/PolymathNetwork/polymath-core/badge.svg?branch=master)](https://coveralls.io/github/PolymathNetwork/polymath-core?branch=master)
 [![Gitter](https://img.shields.io/badge/chat-gitter-green.svg)](https://gitter.im/PolymathNetwork/Lobby)
 [![Telegram](https://img.shields.io/badge/50k+-telegram-blue.svg)](https://gitter.im/PolymathNetwork/Lobby) [![Greenkeeper badge](https://badges.greenkeeper.io/PolymathNetwork/polymath-core.svg)](https://greenkeeper.io/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/PolymathNetwork/polymath-core.svg?branch=master)](https://travis-ci.org/PolymathNetwork/polymath-core)
+[![CircleCI](https://circleci.com/gh/maxsam4/polymath-core.svg?style=svg)](https://circleci.com/gh/maxsam4/polymath-core)
 [![Coverage Status](https://coveralls.io/repos/github/PolymathNetwork/polymath-core/badge.svg?branch=master)](https://coveralls.io/github/PolymathNetwork/polymath-core?branch=master)
 [![Gitter](https://img.shields.io/badge/chat-gitter-green.svg)](https://gitter.im/PolymathNetwork/Lobby)
 [![Telegram](https://img.shields.io/badge/50k+-telegram-blue.svg)](https://gitter.im/PolymathNetwork/Lobby) [![Greenkeeper badge](https://badges.greenkeeper.io/PolymathNetwork/polymath-core.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ethereumjs-abi": "^0.6.5",
     "fast-csv": "^2.4.1",
     "ganache-cli": "^6.1.8",
+    "mocha-junit-reporter": "^1.18.0",
     "prettier": "^1.14.3",
     "sol-merger": "^0.1.2",
     "solidity-coverage": "^0.5.11",

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -2,4 +2,4 @@
 
 rm -rf flat
 
-TRAVIS_PULL_REQUEST=true scripts/test.sh
+COVERAGE=true scripts/test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,11 +19,7 @@ cleanup() {
   fi
 }
 
-if ! [ -z "${TRAVIS_PULL_REQUEST+x}" ] && [ "$TRAVIS_PULL_REQUEST" != false ]; then
-  testrpc_port=8545
-else
-  testrpc_port=8545
-fi
+testrpc_port=8545
 
 testrpc_running() {
   nc -z localhost "$testrpc_port"
@@ -60,20 +56,19 @@ start_testrpc() {
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501209,1000000000000000000000000"
   )
 
-  if ! [ -z "${TRAVIS_PULL_REQUEST+x}" ] && [ "$TRAVIS_PULL_REQUEST" != false ]; then
+  if [ "$COVERAGE" = true ]; then
     node_modules/.bin/testrpc-sc --gasLimit 0xfffffffffff --port "$testrpc_port" "${accounts[@]}" > /dev/null &
   else
     node_modules/.bin/ganache-cli --gasLimit 8000000 "${accounts[@]}" > /dev/null &
   fi
-
 
   testrpc_pid=$!
 }
 
 if testrpc_running; then
   echo "Using existing testrpc instance"
-  # Do not start ethereum bridge unless it is a cron job from travis
-  if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+  # Do not start ethereum bridge unless it is a cron job
+  if [ "$CIRCLE_CI_CRON" = true ]; then
     bridge_running
     if bridge_running; then
       echo "Using existing ethereum-bridge instance"
@@ -85,23 +80,23 @@ if testrpc_running; then
 else
   echo "Starting our own testrpc instance"
   start_testrpc
-  # Do not start ethereum bridge unless it is a cron job from travis
-  if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+  # Do not start ethereum bridge unless it is a cron job
+  if [ "$CIRCLE_CI_CRON" = true ]; then
     echo "Starting our own ethereum-bridge instance"
     sleep 10
     start_bridge
   fi
 fi
 
-if ! [ -z "${TRAVIS_PULL_REQUEST+x}" ] && [ "$TRAVIS_PULL_REQUEST" != false ]; then
+if [ "$COVERAGE" = true ]; then
   curl -o node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
   node_modules/.bin/solidity-coverage
-  if [ "$CONTINUOUS_INTEGRATION" = true ]; then
+  if [ "$CI" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls
   fi
 else
-  # Do not run a_poly_oracle,js tests unless it is a cron job from travis
-  if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+  # Do not run a_poly_oracle,js tests unless it is a cron job
+  if [ "$CIRCLE_CI_CRON" = true ]; then
     node_modules/.bin/truffle test `ls test/*.js`
   else
     node_modules/.bin/truffle test `find test/*.js ! -name a_poly_oracle.js -and ! -name s_v130_to_v140_upgrade.js`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -95,6 +95,12 @@ if [ "$COVERAGE" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls
   fi
 else
+  if [ "$CI" = true ]; then
+    mkdir test-results
+    mkdir test-results/mocha
+    rm truffle-config.js
+    mv truffle-ci.js truffle-config.js
+  fi
   # Do not run a_poly_oracle,js tests unless it is a cron job
   if [ "$CIRCLE_CI_CRON" = true ]; then
     node_modules/.bin/truffle test `ls test/*.js`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -100,10 +100,11 @@ else
     mkdir test-results/mocha
     rm truffle-config.js
     mv truffle-ci.js truffle-config.js
-  fi
-  # Do not run a_poly_oracle,js tests unless it is a cron job
-  if [ "$CIRCLE_CI_CRON" = true ]; then
-    node_modules/.bin/truffle test `ls test/*.js`
+    if [ "$CIRCLE_CI_CRON" = true ]; then
+      node_modules/.bin/truffle test `ls test/*.js | circleci tests split --split-by=timings`
+    else
+      node_modules/.bin/truffle test `find test/*.js ! -name a_poly_oracle.js -and ! -name s_v130_to_v140_upgrade.js | circleci tests split --split-by=timings`
+    fi
   else
     node_modules/.bin/truffle test `find test/*.js ! -name a_poly_oracle.js -and ! -name s_v130_to_v140_upgrade.js`
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -95,7 +95,7 @@ if [ "$COVERAGE" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls
   fi
 else
-  if [ "$CIRCLECI" = true ]; then
+  if [ "$CIRCLECI" = true ]; then # using mocha junit reporter for parallelism in CircleCI 
     mkdir test-results
     mkdir test-results/mocha
     rm truffle-config.js

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -100,6 +100,7 @@ else
     mkdir test-results/mocha
     rm truffle-config.js
     mv truffle-ci.js truffle-config.js
+    # only run poly oracle and upgrade tests if cron job by CI
     if [ "$CIRCLE_CI_CRON" = true ]; then
       node_modules/.bin/truffle test `ls test/*.js | circleci tests split --split-by=timings`
     else

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -91,11 +91,11 @@ fi
 if [ "$COVERAGE" = true ]; then
   curl -o node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
   node_modules/.bin/solidity-coverage
-  if [ "$CI" = true ]; then
+  if [ "$CIRCLECI" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls
   fi
 else
-  if [ "$CI" = true ]; then
+  if [ "$CIRCLECI" = true ]; then
     mkdir test-results
     mkdir test-results/mocha
     rm truffle-config.js

--- a/truffle-ci.js
+++ b/truffle-ci.js
@@ -1,0 +1,33 @@
+require('babel-register');
+require('babel-polyfill');
+
+module.exports = {
+  networks: {
+    development: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '*', // Match any network id
+      gas: 7900000,
+    },
+    coverage: {
+      host: "localhost",
+      network_id: "*",
+      port: 8545,         // <-- If you change this, also set the port option in .solcover.js.
+      gas: 0xfffffffffff, // <-- Use this high gas value
+      gasPrice: 0x01      // <-- Use this low gas price
+    }
+  },
+  solc: {
+    optimizer: {
+      enabled: true,
+      runs: 200,
+    },
+  },
+  mocha: {
+    enableTimeouts: false,
+    reporter: "mocha-junit-reporter",
+    reporterOptions: {
+      mochaFile: './test-results/mocha/results.xml'
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,11 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 checkpoint-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/checkpoint-store/-/checkpoint-store-1.1.0.tgz#04e4cb516b91433893581e6d4601a78e9552ea06"
@@ -1708,6 +1713,11 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+    
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -3545,7 +3555,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -4207,6 +4217,15 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+md5@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -4406,11 +4425,26 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
+<<<<<<< HEAD
 mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+=======
+mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+>>>>>>> e543061f... Added test reporter
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha-junit-reporter@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.18.0.tgz#9209a3fba30025ae3ae5e6bfe7f9c5bc3c2e8ee2"
+  integrity sha512-y3XuqKa2+HRYtg0wYyhW/XsLm2Ps+pqf9HaTAt7+MVUAKFJaNAHOrNseTZo9KCxjfIbxUWwckP5qCDDPUmjSWA==
+  dependencies:
+    debug "^2.2.0"
+    md5 "^2.1.0"
+    mkdirp "~0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.0"
 
 mocha@^4.0.1, mocha@^4.1.0:
   version "4.1.0"
@@ -7123,6 +7157,11 @@ xhr@^2.0.4, xhr@^2.2.0, xhr@^2.3.3:
     is-function "^1.0.1"
     parse-headers "^2.0.0"
     xtend "^4.0.0"
+
+xml@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlhttprequest@*, xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
TODO

1. Enable CircleCI
2. Set coveralls repo token in CircleCI environment
3. Set Github login username and password in CircleCI environment for pushing docs
4. Disable PR builds in Travis as coverage is now handled by CircleCI

Main changes in the CI workflow:

1. Travis is used for tests
2. CircleCI is used for coverage and docs
3. Docs are only generated when a commit is pushed to master branch
4. Coverage is now generated for every commit rather than only PR commits

I have also configured our test script to support parallelism offered by CircleCI. i.e, if in future we move tests to CircleCI from Travis, we will be able to split tests into X simultaneous parts for faster execution. Timing data of various configs available on Asana.