### PR TITLE
Using truffle 5 + native solc for coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run: truffle version
       - run: node_modules/.bin/truffle version
       - run: 
-          command: npm run coverage
+          command: scripts/coverage.sh
           no_output_timeout: 1h
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,15 @@ jobs:
           path: ./test-results/mocha/results.xml
   coverage:
     docker:
-      - image: circleci/node:8
+      - image: maxsam4/solidity-kit:0.4.24
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: yarn install
-      - run: sudo npm i truffle -g
       - run: node --version
       - run: truffle version
+      - run: node_modules/.bin/truffle version
       - run: 
           command: npm run coverage
           no_output_timeout: 1h

--- a/.solcover.js
+++ b/.solcover.js
@@ -3,6 +3,7 @@ module.exports = {
     port: 8545,
     copyPackages: ['openzeppelin-solidity'],
     testCommand: 'node ../node_modules/.bin/truffle test `find test/*.js ! -name a_poly_oracle.js -and ! -name s_v130_to_v140_upgrade.js -and ! -name q_usd_tiered_sto_sim.js -and ! -name z_general_permission_manager_fuzzer.js` --network coverage',
+    compileCommand: 'truffle version && truffle compile',
     deepSkip: true,
     skipFiles: ['external', 'flat', 'helpers', 'mocks', 'oracles', 'libraries/KindMath.sol', 'libraries/BokkyPooBahsDateTimeLibrary.sol', 'storage', 'modules/Experimental'],        
     forceParse: ['mocks', 'oracles', 'modules/Experimental']

--- a/.solcover.js
+++ b/.solcover.js
@@ -3,7 +3,6 @@ module.exports = {
     port: 8545,
     copyPackages: ['openzeppelin-solidity'],
     testCommand: 'node ../node_modules/.bin/truffle test `find test/*.js ! -name a_poly_oracle.js -and ! -name s_v130_to_v140_upgrade.js -and ! -name q_usd_tiered_sto_sim.js -and ! -name z_general_permission_manager_fuzzer.js` --network coverage',
-    compileCommand: 'truffle version && truffle compile',
     deepSkip: true,
     skipFiles: ['external', 'flat', 'helpers', 'mocks', 'oracles', 'libraries/KindMath.sol', 'libraries/BokkyPooBahsDateTimeLibrary.sol', 'storage', 'modules/Experimental'],        
     forceParse: ['mocks', 'oracles', 'modules/Experimental']

--- a/contracts/modules/TransferManager/VolumeRestrictionTM.sol
+++ b/contracts/modules/TransferManager/VolumeRestrictionTM.sol
@@ -955,31 +955,22 @@ contract VolumeRestrictionTM is VolumeRestrictionTMStorage, ITransferManager {
             counter = counter.add(_diffDays);
         } else {
             for (i = 0; i < _diffDays; i++) {
-            counter++;
-            // This condition is to check whether the first rolling period is covered or not
-            // if not then it continues and adding 0 value into sumOfLastPeriod without subtracting
-            // the earlier value at that index
-            if (counter >= _rollingPeriodInDays) {
-                // Subtracting the former value(Sum of all the txn amount of that day) from the sumOfLastPeriod
-                // The below line subtracts (the traded volume on days no longer covered by rolling period) from sumOfLastPeriod.
-                // Every loop execution subtracts one day's trade volume. 
-                // Loop starts from the first day covered in sumOfLastPeriod upto the day that is covered by rolling period.
-                sumOfLastPeriod = 
-                    sumOfLastPeriod.sub(
-                        bucket[_from][_bucketDetails.lastTradedDayTime.sub(
-                            (
-                                _bucketDetails.daysCovered.sub(
-                                    counter.sub(
-                                        _rollingPeriodInDays
-                                    )
-                                )
-                            ).mul(1 days)
-                        )]
-                    );
-            }
-            // Adding the last amount that is transacted on the `_fromTime` not actually doing it but left written to understand
-            // the alogrithm
-            //_bucketDetails.sumOfLastPeriod = _bucketDetails.sumOfLastPeriod.add(uint256(0));
+                counter++;
+                // This condition is to check whether the first rolling period is covered or not
+                // if not then it continues and adding 0 value into sumOfLastPeriod without subtracting
+                // the earlier value at that index
+                if (counter >= _rollingPeriodInDays) {
+                    // Subtracting the former value(Sum of all the txn amount of that day) from the sumOfLastPeriod
+                    // The below line subtracts (the traded volume on days no longer covered by rolling period) from sumOfLastPeriod.
+                    // Every loop execution subtracts one day's trade volume. 
+                    // Loop starts from the first day covered in sumOfLastPeriod upto the day that is covered by rolling period.
+                    uint256 temp = _bucketDetails.daysCovered.sub(counter.sub(_rollingPeriodInDays));
+                    temp = _bucketDetails.lastTradedDayTime.sub(temp.mul(1 days));
+                    sumOfLastPeriod = sumOfLastPeriod.sub(bucket[_from][temp]);
+                }
+                // Adding the last amount that is transacted on the `_fromTime` not actually doing it but left written to understand
+                // the alogrithm
+                //_bucketDetails.sumOfLastPeriod = _bucketDetails.sumOfLastPeriod.add(uint256(0));
             }
         }
         // calculating the timestamp that will used as an index of the next bucket

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -90,6 +90,8 @@ fi
 
 if [ "$COVERAGE" = true ] || [ "$TRAVIS_PULL_REQUEST" > 0 ] && [ "$NOT_FORK" != true ]; then
   curl -o node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
+  rm truffle-config.js
+  mv truffle-ci.js truffle-config.js
   node_modules/.bin/solidity-coverage
   if [ "$CIRCLECI" = true ] || [ "$TRAVIS_PULL_REQUEST" > 0 ] && [ "$NOT_FORK" != true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls || echo 'Failed to report coverage to Coveralls'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -90,8 +90,10 @@ fi
 
 if [ "$COVERAGE" = true ] || [ "$TRAVIS_PULL_REQUEST" > 0 ] && [ "$NOT_FORK" != true ]; then
   curl -o node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
-  rm truffle-config.js
-  mv truffle-ci.js truffle-config.js
+  if [ "$CIRCLECI" = true ]; then
+    rm truffle-config.js
+    mv truffle-ci.js truffle-config.js
+  fi
   node_modules/.bin/solidity-coverage
   if [ "$CIRCLECI" = true ] || [ "$TRAVIS_PULL_REQUEST" > 0 ] && [ "$NOT_FORK" != true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls || echo 'Failed to report coverage to Coveralls'

--- a/truffle-ci.js
+++ b/truffle-ci.js
@@ -35,10 +35,6 @@ module.exports = {
     },
   },
   mocha: {
-    enableTimeouts: false,
-    reporter: "mocha-junit-reporter",
-    reporterOptions: {
-      mochaFile: './test-results/mocha/results.xml'
-    }
+    enableTimeouts: false
   }
 };

--- a/truffle-ci.js
+++ b/truffle-ci.js
@@ -17,6 +17,17 @@ module.exports = {
       gasPrice: 0x01      // <-- Use this low gas price
     }
   },
+  compilers: {
+    solc: {
+      version: "native",  
+      settings: {
+        optimizer: {
+          enabled: true, 
+          runs: 200    
+        }
+      }
+    }
+  },
   solc: {
     optimizer: {
       enabled: true,


### PR DESCRIPTION
As splitting coverage didn't work, this is another hack aimed to workaround the maximum contract size restriction of solc-js. 

As a plus point, using native solc speeds up the coverage generation by ~4 minutes.

This pr also includes a minor refactor in VRTM to allow processing of it by solidity-coverage.