### PR TITLE
CLI: FIX: Security Token Registry Getters

### DIFF
--- a/CLI/commands/ST20Generator.js
+++ b/CLI/commands/ST20Generator.js
@@ -193,7 +193,7 @@ async function approvePoly(spender, fee) {
   polyBalance = await polyToken.methods.balanceOf(Issuer.address).call();
   let requiredAmount = web3.utils.toWei(fee.toString(), "ether");
   if (parseInt(polyBalance) >= parseInt(requiredAmount)) {
-    let allowance = await polyToken.methods.allowance(spender, Issuer.address).call();
+    let allowance = await polyToken.methods.allowance(Issuer.address, spender).call();
     if (allowance == web3.utils.toWei(fee.toString(), "ether")) {
       return true;
     } else {

--- a/CLI/commands/ST20Generator.js
+++ b/CLI/commands/ST20Generator.js
@@ -14,6 +14,7 @@ let tokenLaunched;
 
 // Artifacts
 let securityTokenRegistry;
+let strGetter;
 let polyToken;
 
 async function executeApp(_ticker, _transferOwnership, _name, _details, _divisible) {
@@ -47,6 +48,9 @@ async function setup() {
     let securityTokenRegistryABI = abis.securityTokenRegistry();
     securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
     securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
 
     let polytokenAddress = await contracts.polyToken();
     let polytokenABI = abis.polyToken();
@@ -62,7 +66,7 @@ async function setup() {
 async function step_ticker_registration(_ticker) {
   console.log(chalk.blue('\nToken Symbol Registration'));
 
-  let regFee = web3.utils.fromWei(await securityTokenRegistry.methods.getTickerRegistrationFee().call());
+  let regFee = web3.utils.fromWei(await strGetter.methods.getTickerRegistrationFee().call());
   let available = false;
 
   while (!available) {
@@ -75,7 +79,7 @@ async function step_ticker_registration(_ticker) {
       tokenSymbol = await selectTicker();
     }
 
-    let details = await securityTokenRegistry.methods.getTickerDetails(tokenSymbol).call();
+    let details = await strGetter.methods.getTickerDetails(tokenSymbol).call();
     if (new BigNumber(details[1]).toNumber() == 0) {
       // If it has no registration date, it is available
       available = true;
@@ -119,7 +123,7 @@ async function step_transfer_ticker_ownership(_transferOwnership) {
 async function step_token_deploy(_name, _details, _divisible) {
   console.log(chalk.blue('\nToken Creation - Token Deployment'));
 
-  let launchFee = web3.utils.fromWei(await securityTokenRegistry.methods.getSecurityTokenLaunchFee().call());
+  let launchFee = web3.utils.fromWei(await strGetter.methods.getSecurityTokenLaunchFee().call());
   console.log(chalk.green(`\nToken deployment requires ${launchFee} POLY & deducted from '${Issuer.address}', Current balance is ${(web3.utils.fromWei(await polyToken.methods.balanceOf(Issuer.address).call()))} POLY\n`));
 
   let tokenName;
@@ -159,12 +163,12 @@ async function step_token_deploy(_name, _details, _divisible) {
 //////////////////////
 async function selectTicker() {
   let result;
-  let userTickers = (await securityTokenRegistry.methods.getTickersByOwner(Issuer.address).call()).map(t => web3.utils.hexToAscii(t));
+  let userTickers = (await strGetter.methods.getTickersByOwner(Issuer.address).call()).map(t => web3.utils.hexToAscii(t));
   let options = await Promise.all(userTickers.map(async function (t) {
-    let tickerDetails = await securityTokenRegistry.methods.getTickerDetails(t).call();
+    let tickerDetails = await strGetter.methods.getTickerDetails(t).call();
     let tickerInfo;
     if (tickerDetails[4]) {
-      tickerInfo = `Token launched at ${(await securityTokenRegistry.methods.getSecurityTokenAddress(t).call())}`;
+      tickerInfo = `Token launched at ${(await strGetter.methods.getSecurityTokenAddress(t).call())}`;
     } else {
       tickerInfo = `Expires at ${moment.unix(tickerDetails[2]).format('MMMM Do YYYY, HH:mm:ss')}`;
     }

--- a/CLI/commands/TickerRollForward.js
+++ b/CLI/commands/TickerRollForward.js
@@ -17,6 +17,7 @@ let totalGas = BigNumber(0);
 
 let polyToken;
 let securityTokenRegistry;
+let strGetter;
 let securityTokenRegistryAddress;
 
 function Ticker(_owner, _symbol, _name) {
@@ -48,6 +49,9 @@ async function startScript() {
   let securityTokenRegistryABI = abis.securityTokenRegistry();
   securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
   securityTokenRegistry.setProvider(web3.currentProvider);
+  let strGetterABI = abis.strGetter();
+  strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+  strGetter.setProvider(web3.currentProvider);
 
   let polytokenAddress = await contracts.polyToken();
   let polytokenABI = abis.polyToken();
@@ -73,7 +77,7 @@ async function readFile() {
 async function registerTickers() {
   // Poly approval for registration fees
   let polyBalance = BigNumber(await polyToken.methods.balanceOf(Issuer.address).call());
-  let fee = web3.utils.fromWei(await securityTokenRegistry.methods.getTickerRegistrationFee().call());
+  let fee = web3.utils.fromWei(await strGetter.methods.getTickerRegistrationFee().call());
   let totalFee = BigNumber(ticker_data.length).mul(fee);
 
   if (totalFee.gt(polyBalance)) {
@@ -100,7 +104,7 @@ async function registerTickers() {
     }
 
     // validate ticker
-    await securityTokenRegistry.methods.getTickerDetails(ticker_data[i].symbol).call({}, function (error, result) {
+    await strGetter.methods.getTickerDetails(ticker_data[i].symbol).call({}, function (error, result) {
       if (result[1] != 0) {
         failed_tickers.push(` ${i} is already registered`);
         valid = false;

--- a/CLI/commands/dividends_manager.js
+++ b/CLI/commands/dividends_manager.js
@@ -15,7 +15,7 @@ const TAX_WITHHOLDING_DATA_CSV = `${__dirname}/../data/Checkpoint/tax_withholdin
 let tokenSymbol;
 let securityToken;
 let polyToken;
-let securityTokenRegistry;
+let strGetter;
 let moduleRegistry;
 let currentDividendsModule;
 
@@ -810,7 +810,7 @@ async function initialize(_tokenSymbol) {
   } else {
     tokenSymbol = _tokenSymbol;
   }
-  let securityTokenAddress = await securityTokenRegistry.methods.getSecurityTokenAddress(tokenSymbol).call();
+  let securityTokenAddress = await strGetter.methods.getSecurityTokenAddress(tokenSymbol).call();
   if (securityTokenAddress == '0x0000000000000000000000000000000000000000') {
     console.log(chalk.red(`Selected Security Token ${tokenSymbol} does not exist.`));
     process.exit(0);
@@ -831,9 +831,9 @@ function welcome() {
 async function setup() {
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-    let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
 
     let polyTokenAddress = await contracts.polyToken();
     let polyTokenABI = abis.polyToken();
@@ -854,9 +854,9 @@ async function setup() {
 async function selectToken() {
   let result = null;
 
-  let userTokens = await securityTokenRegistry.methods.getTokensByOwner(Issuer.address).call();
+  let userTokens = await strGetter.methods.getTokensByOwner(Issuer.address).call();
   let tokenDataArray = await Promise.all(userTokens.map(async function (t) {
-    let tokenData = await securityTokenRegistry.methods.getSecurityTokenData(t).call();
+    let tokenData = await strGetter.methods.getSecurityTokenData(t).call();
     return { symbol: tokenData[0], address: t };
   }));
   let options = tokenDataArray.map(function (t) {

--- a/CLI/commands/helpers/contract_abis.js
+++ b/CLI/commands/helpers/contract_abis.js
@@ -1,5 +1,6 @@
 let polymathRegistryABI;
 let securityTokenRegistryABI;
+let strGetterABI;
 let featureRegistryABI;
 let moduleRegistryABI;
 let securityTokenABI;
@@ -29,6 +30,7 @@ let erc20ABI;
 try {
     polymathRegistryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/PolymathRegistry.json`).toString()).abi;
     securityTokenRegistryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/SecurityTokenRegistry.json`).toString()).abi;
+    strGetterABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/STRGetter.json`).toString()).abi;
     featureRegistryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/FeatureRegistry.json`).toString()).abi;
     moduleRegistryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ModuleRegistry.json`).toString()).abi;
     securityTokenABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/SecurityToken.json`).toString()).abi;
@@ -53,7 +55,7 @@ try {
     iSTOABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ISTO.json`).toString()).abi
     iTransferManagerABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ITransferManager.json`).toString()).abi
     moduleFactoryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ModuleFactory.json`).toString()).abi;
-    erc20ABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/DetailedERC20.json`).toString()).abi;
+    erc20ABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ERC20Detailed.json`).toString()).abi;
 } catch (err) {
     console.log('\x1b[31m%s\x1b[0m', "Couldn't find contracts' artifacts. Make sure you ran truffle compile first");
     throw err;
@@ -65,6 +67,9 @@ module.exports = {
     },
     securityTokenRegistry: function () {
         return securityTokenRegistryABI;
+    },
+    strGetter: function () {
+        return strGetterABI;
     },
     featureRegistry: function () {
         return featureRegistryABI;

--- a/CLI/commands/investor_portal.js
+++ b/CLI/commands/investor_portal.js
@@ -499,7 +499,7 @@ async function investCappedSTO(currency, amount) {
     if (raiseTypes[0] == 'POLY') {
         let userBalance = await polyBalance(User.address);
         if (parseInt(userBalance) >= parseInt(cost)) {
-            let allowance = await polyToken.methods.allowance(STOAddress, User.address).call();
+            let allowance = await polyToken.methods.allowance(User.address, STOAddress).call();
             if (allowance < costWei) {
                 let approveAction = polyToken.methods.approve(STOAddress, costWei);
                 await common.sendTransaction(approveAction, { from: User });
@@ -607,7 +607,7 @@ async function investUsdTieredSTO(currency, amount) {
     if (raiseType == POLY) {
         let userBalance = await polyBalance(User.address);
         if (parseInt(userBalance) >= parseInt(cost)) {
-            let allowance = await polyToken.methods.allowance(STOAddress, User.address).call();
+            let allowance = await polyToken.methods.allowance(User.address, STOAddress).call();
             if (allowance < costWei) {
                 let approveAction = polyToken.methods.approve(STOAddress, costWei);
                 await common.sendTransaction(approveAction, { from: User });

--- a/CLI/commands/investor_portal.js
+++ b/CLI/commands/investor_portal.js
@@ -152,7 +152,6 @@ async function showTokenInfo() {
 
 // Show info
 async function showUserInfo(_user) {
-    let listOfStableCoins = await currentSTO.methods.getUsdTokens().call();
 
     console.log(`
     *******************    User Information    ********************
@@ -164,6 +163,7 @@ async function showUserInfo(_user) {
         console.log(`    - ETH balance:\t     ${web3.utils.fromWei(await web3.eth.getBalance(_user))}`);
     }
     if (await currentSTO.methods.fundRaiseTypes(gbl.constants.FUND_RAISE_TYPES.STABLE).call()) {
+        let listOfStableCoins = await currentSTO.methods.getUsdTokens().call();
         let stableSymbolsAndBalance = await processAddressWithBalance(listOfStableCoins);
         stableSymbolsAndBalance.forEach(stable => {
             console.log(`    - ${stable.symbol} balance:\t     ${web3.utils.fromWei(stable.balance)}`);

--- a/CLI/commands/investor_portal.js
+++ b/CLI/commands/investor_portal.js
@@ -13,7 +13,7 @@ const ETH = 'ETH';
 const POLY = 'POLY';
 const STABLE = 'STABLE';
 
-let securityTokenRegistry;
+let strGetter;
 let securityToken;
 let selectedSTO;
 let currentSTO;
@@ -83,9 +83,9 @@ async function executeApp(investorAddress, investorPrivKey, symbol, currency, am
 async function setup() {
     try {
         let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-        let securityTokenRegistryABI = abis.securityTokenRegistry();
-        securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-        securityTokenRegistry.setProvider(web3.currentProvider);
+        let strGetterABI = abis.strGetter();
+        strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+        strGetter.setProvider(web3.currentProvider);
 
         let polytokenAddress = await contracts.polyToken();
         let polytokenABI = abis.polyToken();
@@ -108,7 +108,7 @@ async function inputSymbol(symbol) {
 
     if (STSymbol == "") process.exit();
 
-    STAddress = await securityTokenRegistry.methods.getSecurityTokenAddress(STSymbol).call();
+    STAddress = await strGetter.methods.getSecurityTokenAddress(STSymbol).call();
     if (STAddress == "0x0000000000000000000000000000000000000000") {
         console.log(`Token symbol provided is not a registered Security Token. Please enter another symbol.`);
     } else {

--- a/CLI/commands/permission_manager.js
+++ b/CLI/commands/permission_manager.js
@@ -7,7 +7,7 @@ var abis = require('./helpers/contract_abis');
 
 // App flow
 let tokenSymbol;
-let securityTokenRegistry;
+let strGetter;
 let securityToken;
 let generalPermissionManager;
 let isNewDelegate = false;
@@ -35,9 +35,9 @@ async function executeApp() {
 async function setup(){
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-    let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
   } catch (err) {
     console.log(err)
     console.log('\x1b[31m%s\x1b[0m',"There was a problem getting the contracts. Make sure they are deployed to the selected network.");
@@ -49,7 +49,7 @@ async function selectST() {
   if (!tokenSymbol)
     tokenSymbol = readlineSync.question('Enter the token symbol: ');
 
-  let result = await securityTokenRegistry.methods.getSecurityTokenAddress(tokenSymbol).call();
+  let result = await strGetter.methods.getSecurityTokenAddress(tokenSymbol).call();
   if (result == "0x0000000000000000000000000000000000000000") {
     tokenSymbol = undefined;
     console.log(chalk.red(`Token symbol provided is not a registered Security Token.`));
@@ -118,10 +118,10 @@ async function selectDelegate() {
   let result;
   let delegates = await getDelegates();
   let permissions = await getDelegatesAndPermissions();
-  
+
   let options = ['Add new delegate'];
 
-  options = options.concat(delegates.map(function(d) { 
+  options = options.concat(delegates.map(function(d) {
     let perm = renderTable(permissions, d.address);
 
     return `Account: ${d.address}
@@ -142,7 +142,7 @@ async function selectDelegate() {
 
 async function selectModule() {
   let modules = await getModulesWithPermissions();
-  let options = modules.map(function(m) { 
+  let options = modules.map(function(m) {
     return m.name;
   });
   let index = readlineSync.keyInSelect(options, 'Select a module:', {cancel: false});
@@ -216,14 +216,14 @@ async function addNewDelegate() {
 async function getModulesWithPermissions() {
   let modules = [];
   let moduleABI = abis.moduleInterface();
-  
+
   for (const type in gbl.constants.MODULES_TYPES) {
     let modulesAttached = await securityToken.methods.getModulesByType(gbl.constants.MODULES_TYPES[type]).call();
     for (const m of modulesAttached) {
       let contractTemp = new web3.eth.Contract(moduleABI, m);
       let permissions = await contractTemp.methods.getPermissions().call();
       if (permissions.length > 0) {
-        modules.push({ 
+        modules.push({
           name: web3.utils.hexToAscii((await securityToken.methods.getModule(m).call())[0]),
           address: m,
           permissions: permissions.map(function (p) { return web3.utils.hexToAscii(p) })
@@ -251,7 +251,7 @@ async function getDelegatesAndPermissions() {
           for (delegateAddr of allDelegates) {
             if (result[delegateAddr] == undefined) {
               result[delegateAddr] = []
-            } 
+            }
             if (result[delegateAddr][moduleName + '-' + module] == undefined) {
               result[delegateAddr][moduleName + '-' + module] = [{permission: permissionName}]
             } else {

--- a/CLI/commands/sto_manager.js
+++ b/CLI/commands/sto_manager.js
@@ -19,7 +19,7 @@ let tokenSymbol;
 
 ////////////////////////
 // Artifacts
-let securityTokenRegistry;
+let strGetter;
 let moduleRegistry;
 let polyToken;
 let usdToken;
@@ -1020,7 +1020,7 @@ async function initialize(_tokenSymbol) {
   } else {
     tokenSymbol = _tokenSymbol;
   }
-  let securityTokenAddress = await securityTokenRegistry.methods.getSecurityTokenAddress(tokenSymbol).call();
+  let securityTokenAddress = await strGetter.methods.getSecurityTokenAddress(tokenSymbol).call();
   if (securityTokenAddress == '0x0000000000000000000000000000000000000000') {
     console.log(chalk.red(`Selected Security Token ${tokenSymbol} does not exist.`));
     process.exit(0);
@@ -1042,9 +1042,9 @@ function welcome() {
 async function setup() {
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-    let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
 
     let moduleRegistryAddress = await contracts.moduleRegistry();
     let moduleRegistryABI = abis.moduleRegistry();
@@ -1070,9 +1070,9 @@ async function setup() {
 async function selectToken() {
   let result = null;
 
-  let userTokens = await securityTokenRegistry.methods.getTokensByOwner(Issuer.address).call();
+  let userTokens = await strGetter.methods.getTokensByOwner(Issuer.address).call();
   let tokenDataArray = await Promise.all(userTokens.map(async function (t) {
-    let tokenData = await securityTokenRegistry.methods.getSecurityTokenData(t).call();
+    let tokenData = await strGetter.methods.getSecurityTokenData(t).call();
     return { symbol: tokenData[0], address: t };
   }));
   let options = tokenDataArray.map(function (t) {

--- a/CLI/commands/sto_manager.js
+++ b/CLI/commands/sto_manager.js
@@ -171,7 +171,7 @@ async function cappedSTO_launch(stoConfig) {
       let transferAction = polyToken.methods.transfer(securityToken._address, transferAmount);
       let receipt = await common.sendTransaction(transferAction, { factor: 2 });
       let event = common.getEventFromLogs(polyToken._jsonInterface, receipt.logs, 'Transfer');
-      console.log(`Number of POLY sent: ${web3.utils.fromWei(new web3.utils.BN(event._value))}`)
+      console.log(`Number of POLY sent: ${web3.utils.fromWei(new web3.utils.BN(event.value))}`)
     }
   }
 
@@ -536,7 +536,7 @@ async function usdTieredSTO_launch(stoConfig) {
       let transferAction = polyToken.methods.transfer(securityToken._address, transferAmount);
       let receipt = await common.sendTransaction(transferAction, { factor: 2 });
       let event = common.getEventFromLogs(polyToken._jsonInterface, receipt.logs, 'Transfer');
-      console.log(`Number of POLY sent: ${web3.utils.fromWei(new web3.utils.BN(event._value))}`)
+      console.log(`Number of POLY sent: ${web3.utils.fromWei(new web3.utils.BN(event.value))}`)
     }
   }
 

--- a/CLI/commands/token_manager.js
+++ b/CLI/commands/token_manager.js
@@ -297,7 +297,7 @@ async function mintTokens() {
       let fromTime = readlineSync.questionInt('Enter the time (Unix Epoch time) when the sale lockup period ends and the investor can freely sell his tokens: ');
       let toTime = readlineSync.questionInt('Enter the time (Unix Epoch time) when the purchase lockup period ends and the investor can freely purchase tokens from others: ');
       let expiryTime = readlineSync.questionInt('Enter the time till investors KYC will be validated (after that investor need to do re-KYC): ');
-      let canBuyFromSTO = readlineSync.keyInYNStrict('Is the investor a restricted investor?');
+      let canBuyFromSTO = readlineSync.keyInYNStrict('Can the investor buy from security token offerings?');
       await modifyWhitelist(investor, fromTime, toTime, expiryTime, canBuyFromSTO);
       break;
     case 'Mint tokens to a single address':

--- a/CLI/commands/token_manager.js
+++ b/CLI/commands/token_manager.js
@@ -14,7 +14,7 @@ const MULTIMINT_DATA_CSV = './CLI/data/ST/multi_mint_data.csv';
 const contracts = require('./helpers/contract_addresses');
 const abis = require('./helpers/contract_abis');
 
-let securityTokenRegistry;
+let strGetter;
 let polyToken;
 let featureRegistry;
 let securityToken;
@@ -25,9 +25,9 @@ let tokenSymbol
 async function setup() {
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-    let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
 
     let polytokenAddress = await contracts.polyToken();
     let polytokenABI = abis.polyToken();
@@ -643,7 +643,7 @@ async function initialize(_tokenSymbol) {
   } else {
     tokenSymbol = _tokenSymbol;
   }
-  let securityTokenAddress = await securityTokenRegistry.methods.getSecurityTokenAddress(tokenSymbol).call();
+  let securityTokenAddress = await strGetter.methods.getSecurityTokenAddress(tokenSymbol).call();
   if (securityTokenAddress == '0x0000000000000000000000000000000000000000') {
     console.log(chalk.red(`Selected Security Token ${tokenSymbol} does not exist.`));
     process.exit(0);
@@ -665,9 +665,9 @@ function welcome() {
 async function selectToken() {
   let result = null;
 
-  let userTokens = await securityTokenRegistry.methods.getTokensByOwner(Issuer.address).call();
+  let userTokens = await strGetter.methods.getTokensByOwner(Issuer.address).call();
   let tokenDataArray = await Promise.all(userTokens.map(async function (t) {
-    let tokenData = await securityTokenRegistry.methods.getSecurityTokenData(t).call();
+    let tokenData = await strGetter.methods.getSecurityTokenData(t).call();
     return { symbol: tokenData[0], address: t };
   }));
   let options = tokenDataArray.map(function (t) {

--- a/CLI/commands/transfer.js
+++ b/CLI/commands/transfer.js
@@ -10,6 +10,7 @@ let _transferTo; //investment beneficiary
 let _transferAmount; //ETH investment
 
 let securityToken;
+let strGetter;
 
 //////////////////////////////////////////ENTRY INTO SCRIPT//////////////////////////////////////////
 
@@ -21,8 +22,9 @@ async function startScript(tokenSymbol, transferTo, transferAmount) {
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
     let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
     transfer();
   } catch (err) {
     console.log(err)
@@ -33,7 +35,7 @@ async function startScript(tokenSymbol, transferTo, transferAmount) {
 
 async function transfer() {
   // Let's check if token has already been deployed, if it has, skip to STO
-  await securityTokenRegistry.methods.getSecurityTokenAddress(_tokenSymbol).call({}, function (error, result) {
+  await strGetter.methods.getSecurityTokenAddress(_tokenSymbol).call({}, function (error, result) {
     if (result != "0x0000000000000000000000000000000000000000") {
       console.log('\x1b[32m%s\x1b[0m', "Token deployed at address " + result + ".");
       let securityTokenABI = abis.securityToken();

--- a/CLI/commands/transfer_manager.js
+++ b/CLI/commands/transfer_manager.js
@@ -49,7 +49,7 @@ const MATM_MENU_OPERATE_REVOKE = 'Revoke multiple approvals in batch';
 // App flow
 let tokenSymbol;
 let securityToken;
-let securityTokenRegistry;
+let strGetter;
 let moduleRegistry;
 let currentTransferManager;
 
@@ -204,8 +204,8 @@ async function forcedTransfers() {
       let forceTransferAction = securityToken.methods.forceTransfer(from, to, web3.utils.toWei(amount), web3.utils.asciiToHex(data), web3.utils.asciiToHex(log));
       let forceTransferReceipt = await common.sendTransaction(forceTransferAction, { factor: 1.5 });
       let forceTransferEvent = common.getEventFromLogs(securityToken._jsonInterface, forceTransferReceipt.logs, 'ForceTransfer');
-      console.log(chalk.green(`  ${forceTransferEvent._controller} has successfully forced a transfer of ${web3.utils.fromWei(forceTransferEvent._value)} ${tokenSymbol} 
-  from ${forceTransferEvent._from} to ${forceTransferEvent._to} 
+      console.log(chalk.green(`  ${forceTransferEvent._controller} has successfully forced a transfer of ${web3.utils.fromWei(forceTransferEvent._value)} ${tokenSymbol}
+  from ${forceTransferEvent._from} to ${forceTransferEvent._to}
   Verified transfer: ${forceTransferEvent._verifyTransfer}
   Data: ${web3.utils.hexToAscii(forceTransferEvent._data)}
         `));
@@ -414,7 +414,7 @@ async function generalTransferManager() {
           return web3.utils.isAddress(input);
         },
         limitMessage: "Must be a valid address"
-      }); 
+      });
       let fromTimeSigned = readlineSync.questionInt('Enter the time (Unix Epoch time) when the sale lockup period ends and the investor can freely sell his tokens: ');
       let toTimeSigned = readlineSync.questionInt('Enter the time (Unix Epoch time) when the purchase lockup period ends and the investor can freely purchase tokens from others: ');
       let expiryTimeSigned = readlineSync.questionInt('Enter the time till investors KYC will be validated (after that investor need to do re-KYC): ');
@@ -2657,7 +2657,7 @@ async function initialize(_tokenSymbol) {
   } else {
     tokenSymbol = _tokenSymbol;
   }
-  let securityTokenAddress = await securityTokenRegistry.methods.getSecurityTokenAddress(tokenSymbol).call();
+  let securityTokenAddress = await strGetter.methods.getSecurityTokenAddress(tokenSymbol).call();
   if (securityTokenAddress == '0x0000000000000000000000000000000000000000') {
     console.log(chalk.red(`Selected Security Token ${tokenSymbol} does not exist.`));
     process.exit(0);
@@ -2678,9 +2678,9 @@ function welcome() {
 async function setup() {
   try {
     let securityTokenRegistryAddress = await contracts.securityTokenRegistry();
-    let securityTokenRegistryABI = abis.securityTokenRegistry();
-    securityTokenRegistry = new web3.eth.Contract(securityTokenRegistryABI, securityTokenRegistryAddress);
-    securityTokenRegistry.setProvider(web3.currentProvider);
+    let strGetterABI = abis.strGetter();
+    strGetter = new web3.eth.Contract(strGetterABI, securityTokenRegistryAddress);
+    strGetter.setProvider(web3.currentProvider);
 
     let moduleRegistryAddress = await contracts.moduleRegistry();
     let moduleRegistryABI = abis.moduleRegistry();
@@ -2696,9 +2696,9 @@ async function setup() {
 async function selectToken() {
   let result = null;
 
-  let userTokens = await securityTokenRegistry.methods.getTokensByOwner(Issuer.address).call();
+  let userTokens = await strGetter.methods.getTokensByOwner(Issuer.address).call();
   let tokenDataArray = await Promise.all(userTokens.map(async function (t) {
-    let tokenData = await securityTokenRegistry.methods.getSecurityTokenData(t).call();
+    let tokenData = await strGetter.methods.getSecurityTokenData(t).call();
     return { symbol: tokenData[0], address: t };
   }));
   let options = tokenDataArray.map(function (t) {

--- a/CLI/commands/transfer_manager.js
+++ b/CLI/commands/transfer_manager.js
@@ -398,7 +398,7 @@ async function generalTransferManager() {
       let toTime = readlineSync.questionInt(`Enter the time (Unix Epoch time) when the purchase lockup period ends and the investor can freely purchase tokens from others (now = ${now}): `, { defaultInput: now });
       let oneHourFromNow = Math.floor(Date.now() / 1000 + 3600);
       let expiryTime = readlineSync.questionInt(`Enter the time till investors KYC will be validated (after that investor need to do re - KYC) (1 hour from now = ${oneHourFromNow}): `, { defaultInput: oneHourFromNow });
-      let canBuyFromSTO = readlineSync.keyInYNStrict('Is the investor a restricted investor?');
+      let canBuyFromSTO = readlineSync.keyInYNStrict('Can the investor buy from security token offerings?');
       let modifyWhitelistAction = currentTransferManager.methods.modifyWhitelist(investor, fromTime, toTime, expiryTime, canBuyFromSTO);
       let modifyWhitelistReceipt = await common.sendTransaction(modifyWhitelistAction);
       let modifyWhitelistEvent = common.getEventFromLogs(currentTransferManager._jsonInterface, modifyWhitelistReceipt.logs, 'ModifyWhitelist');
@@ -421,7 +421,7 @@ async function generalTransferManager() {
       let vSigned = readlineSync.questionInt('Enter v: ');
       let rSigned = readlineSync.question('Enter r: ');
       let sSigned = readlineSync.question('Enter s: ');
-      let canBuyFromSTOSigned = readlineSync.keyInYNStrict('Is the investor a restricted investor?');
+      let canBuyFromSTOSigned = readlineSync.keyInYNStrict('Can the investor buy from security token offerings?');
       let modifyWhitelistSignedAction = currentTransferManager.methods.modifyWhitelistSigned(investorSigned, fromTimeSigned, toTimeSigned, expiryTimeSigned, canBuyFromSTOSigned);
       let modifyWhitelistSignedReceipt = await common.sendTransaction(Issuer, modifyWhitelistSignedAction, defaultGasPrice);
       let modifyWhitelistSignedEvent = common.getEventFromLogs(currentTransferManager._jsonInterface, modifyWhitelistSignedReceipt.logs, 'ModifyWhitelist');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] The commit message follows our Submission guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? 
Fix to broken CLI getters for SecurityTokenRegistry. Getters were broken when getters were broken out into STRGetters.sol from the main contract.

### What is the current behavior? 
Getter functions are no longer found in securityTokenRegistry ABI file.

### What is the new behavior?
Getter functions are correctly called

### Does this PR introduce a breaking change?
No

### Any Other information:
- Would it have been preferable for the ISecurityTokenRegistry to have been called instead of  STRGetters as it also contains interfaces for the getters functions that are called?
- I didn't include strMigrator in these fixes