### PR TITLE
Auto deploy to Kovan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ workflows:
   commit:
     jobs:
       - coverage
-      - deploy_kovan
   daily-builds:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,7 @@ jobs:
       - run: node --version
       - run: truffle version
       - run: mv truffle-ci.js truffle-config.js
-      - run: 
-          command: node_modules/.bin/truffle deploy --network kovan
-          no_output_timeout: 1h
+      - run: npm run deploy-kovan
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
@@ -96,6 +94,7 @@ workflows:
   commit:
     jobs:
       - coverage
+      - deploy_kovan
   daily-builds:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,24 @@ jobs:
             - node_modules
       - store_artifacts:
           path: ./coverage/lcov.info
+  deploy_kovan:
+    docker:
+      - image: maxsam4/solidity-kit:0.4.24
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: yarn install
+      - run: node --version
+      - run: truffle version
+      - run: mv truffle-ci.js truffle-config.js
+      - run: 
+          command: truffle deploy --network kovan
+          no_output_timeout: 1h
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
   docs:
     docker:
       - image: circleci/node:8
@@ -78,6 +96,7 @@ workflows:
   commit:
     jobs:
       - coverage
+      - deploy_kovan
   daily-builds:
     triggers:
       - schedule:
@@ -98,3 +117,13 @@ workflows:
             branches:
               only:
                 - master
+  deploy:
+    jobs:
+      - deploy_kovan:
+          filters:
+            branches:
+              only:
+                - master
+                - dev-2.1.0
+                - dev-2.2.0
+                - dev-3.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ workflows:
   commit:
     jobs:
       - coverage
-      - deploy_kovan
   daily-builds:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run: truffle version
       - run: mv truffle-ci.js truffle-config.js
       - run: 
-          command: truffle deploy --network kovan
+          command: node_modules/.bin/truffle deploy --network kovan
           no_output_timeout: 1h
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "solidity-docgen": "^0.1.0",
     "solium": "^1.1.8",
     "truffle": "4.1.14",
+    "truffle-hdwallet-provider": "^1.0.3",
     "truffle-wallet-provider": "0.0.5"
   },
   "greenkeeper": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "scripts/test.sh 2> /dev/null",
+    "deploy-kovan": "scripts/deploy.sh",
     "wintest": "scripts\\wintest.cmd",
     "wincov": "scripts\\wincov.cmd",
     "docs": "scripts/docs.sh",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+node_modules/.bin/truffle deploy --network kovan
+address=$(grep build/contracts/PolymathRegistry.json -e "\"address\":" | grep -o "0[0-9a-z]*")
+commitId=$(git rev-parse HEAD)
+branchName=$(git rev-parse --abbrev-ref HEAD)
+commitName=$(git log -1 --pretty=%B)
+data='{"text":"Somebody merged a new pull request!\nBranch Name: '$branchName'\nCommit Name: '$commitName'\nCommit ID: '$commitId'\nPolymath Registry Address(Kovan): '$address'"}'
+curl -X POST -H 'Content-type: application/json' --data "$data" ${SLACK_DEVNOTIFACTIONS_WH}

--- a/truffle-ci.js
+++ b/truffle-ci.js
@@ -9,6 +9,13 @@ module.exports = {
       network_id: '*', // Match any network id
       gas: 7900000,
     },
+    kovan: {
+      provider: () => {
+        return new HDWalletProvider(process.env.PRIVATE_KEY, "https://kovan.mudit.blog/");
+      },
+      network_id: '42',
+      gasPrice: 2000000000
+    },
     coverage: {
       host: "localhost",
       network_id: "*",

--- a/truffle-ci.js
+++ b/truffle-ci.js
@@ -1,6 +1,8 @@
 require('babel-register');
 require('babel-polyfill');
 
+let HDWalletProvider = require("truffle-hdwallet-provider");
+
 module.exports = {
   networks: {
     development: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,7 +253,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1024,13 +1024,13 @@ bignumber.js@^8.0.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.1.tgz#5d419191370fb558c64e3e5f70d68e5947138832"
   integrity sha512-zAySveTJXkgLYCBi0b14xzfnOs+f3G6x36I8w2a1+PFQpWk/dp0mI0F+ZZK2bu+3ELewDcSyP+Cfq++NcHX7sg==
 
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
+  version "2.0.7"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
@@ -1045,6 +1045,13 @@ bindings@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz#21fc7c6d67c18516ec5aaa2815b145ff77b26ea5"
   integrity sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==
+
+bindings@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.4.0.tgz#909efa49f2ebe07ecd3cb136778f665052040127"
+  integrity sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bip66@^1.1.3:
   version "1.1.5"
@@ -3030,6 +3037,11 @@ file-type@^6.1.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
   integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -4810,7 +4822,7 @@ nan@2.10.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
   integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
-nan@^2.0.8, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2:
+nan@^2.0.8, nan@^2.11.0, nan@^2.2.1, nan@^2.3.3, nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
@@ -6871,6 +6883,15 @@ truffle-hdwallet-provider-privkey@0.3.0:
     web3 "^0.20.6"
     web3-provider-engine "^13.8.0"
 
+truffle-hdwallet-provider@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.3.tgz#4ae845f9b2de23f47c4f0fbc6ef2d4b13b494604"
+  integrity sha512-Lm4MrXHnWg8wHNUoumUBc8AhlCBg05x7wZA81JOFfO0j3QU53A/hhSfV7v8gANbRsvpF5Su0s3SNQGJjewtnYw==
+  dependencies:
+    any-promise "^1.3.0"
+    bindings "^1.3.1"
+    websocket "^1.0.28"
+
 truffle-wallet-provider@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/truffle-wallet-provider/-/truffle-wallet-provider-0.0.5.tgz#db59ce6fa1c558766011137509a94dfca8d1408e"
@@ -6943,7 +6964,7 @@ typechecker@~2.0.1:
   resolved "https://registry.yarnpkg.com/typechecker/-/typechecker-2.0.8.tgz#e83da84bb64c584ccb345838576c40b0337db82e"
   integrity sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=
 
-typedarray-to-buffer@^3.1.2:
+typedarray-to-buffer@^3.1.2, typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
@@ -7449,6 +7470,16 @@ web3@^0.20.6:
     utf8 "^2.1.1"
     xhr2-cookies "^1.1.0"
     xmlhttprequest "*"
+
+websocket@^1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.28.tgz#9e5f6fdc8a3fe01d4422647ef93abdd8d45a78d3"
+  integrity sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==
+  dependencies:
+    debug "^2.2.0"
+    nan "^2.11.0"
+    typedarray-to-buffer "^3.1.5"
+    yaeti "^0.0.6"
 
 "websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
   version "1.0.26"


### PR DESCRIPTION
Every time a merge is made to master/dev-2.1.0/dev-2.2.0/dev-3.0.0, A fresh set of polymath core contracts will be deployed on Kovan.

Do NOT use these in production. These are only to ease internal testing. To get the address. open the details of check named `auto-deploy` ran by CircleCI and then expand the output of `node_modules/.bin/truffle deploy --network kovan` command.

It costs about 0.25 eth to deploy one set of polymath core. I have topped off the deployer with 20 keth so we should be good for 80 merges to master/dev branches i.e. 80 pull request merges. I'll top it off again when needed.

ps the commit `Use local truffle` has the auto-deploy check finished successfully and the output can be used. The next commit edits the config so that deployment is done only on merge to master/dev branches.

EDIT: A notification with commit details and PM registry address will be posted in slack for easy access.