### PR TITLE
Alternative symbol() ABI for ERC20 tokens

### DIFF
--- a/CLI/commands/helpers/contract_abis.js
+++ b/CLI/commands/helpers/contract_abis.js
@@ -140,5 +140,17 @@ module.exports = {
     },
     erc20: function () {
         return erc20ABI;
+    },
+    alternativeErc20: function () {
+        let alternativeErc20 = [{
+            "constant": true,
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [{ "name": "", "type": "bytes32" }],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        }];
+        return alternativeErc20;
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our Submission guidelines

### What kind of change does this PR introduce? 
Bug fix

### What is the current behavior? 
Some ERC20 tokens store its symbol with bytes32 instead of string. This fails on CLI. 

### What is the new behavior?
When checking if an address is or not an ERC20 token, if the string symbol() check fails, it tries with bytes32 symbol() check.

### Does this PR introduce a breaking change?
No

### Any Other information:
We should check this always in other scripts too.