### PR TITLE
USDTIeredSTO finalize edge case fixed

### DIFF
--- a/contracts/modules/STO/USDTieredSTO.sol
+++ b/contracts/modules/STO/USDTieredSTO.sol
@@ -290,6 +290,9 @@ contract USDTieredSTO is USDTieredSTOStorage, ISTO, ReentrancyGuard {
                 tiers[i].mintedTotal = tiers[i].tokenTotal;
             }
         }
+        uint256 granularity = ISecurityToken(securityToken).granularity();
+        tempReturned = tempReturned.div(granularity);
+        tempReturned = tempReturned.mul(granularity);
         require(ISecurityToken(securityToken).mint(reserveWallet, tempReturned), "Error in minting");
         emit ReserveTokenMint(msg.sender, reserveWallet, tempReturned, currentTier);
         finalAmountReturned = tempReturned;


### PR DESCRIPTION
Fixes the edge case which caused finalize STO to revert. This edge case was due to a granularity error and would have been caused only if the owner entered a nongranular cap or changed the granularity of the token during the STO.