### PR TITLE
Fix dividend bugs

### DIFF
--- a/contracts/mocks/DummySTO.sol
+++ b/contracts/mocks/DummySTO.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
-import "./STO.sol";
-import "../../interfaces/ISecurityToken.sol";
+import "../modules/STO/STO.sol";
+import "../interfaces/ISecurityToken.sol";
 
 /**
  * @title STO module for sample implementation of a different crowdsale module
@@ -89,5 +89,7 @@ contract DummySTO is STO {
         allPermissions[0] = ADMIN;
         return allPermissions;
     }
+
+
 
 }

--- a/contracts/mocks/DummySTO.sol
+++ b/contracts/mocks/DummySTO.sol
@@ -90,6 +90,8 @@ contract DummySTO is STO {
         return allPermissions;
     }
 
-
+    function () payable {
+        //Payable fallback function to allow us to test leaking ETH
+    }
 
 }

--- a/contracts/mocks/DummySTOFactory.sol
+++ b/contracts/mocks/DummySTOFactory.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.24;
 
 import "./DummySTO.sol";
-import "../ModuleFactory.sol";
-import "../../libraries/Util.sol";
+import "../modules/ModuleFactory.sol";
+import "../libraries/Util.sol";
 
 /**
  * @title Factory for deploying DummySTO module

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "../modules/STO/DummySTOFactory.sol";
+import "./DummySTOFactory.sol";
 
 /**
  * @title Mock Contract Not fit for production environment
@@ -32,7 +32,7 @@ contract MockFactory is DummySTOFactory {
             res[1] = 1;
             return res;
         }
-        
+
     }
 
     function changeTypes() external onlyOwner {

--- a/contracts/mocks/TestSTOFactory.sol
+++ b/contracts/mocks/TestSTOFactory.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import "../modules/STO/DummySTOFactory.sol";
+import "./DummySTOFactory.sol";
 
 contract TestSTOFactory is DummySTOFactory {
 

--- a/contracts/modules/Checkpoint/DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/DividendCheckpoint.sol
@@ -26,6 +26,7 @@ contract DividendCheckpoint is DividendCheckpointStorage, ICheckpoint, Module, P
     event SetWithholding(address[] _investors, uint256[] _withholding, uint256 _timestamp);
     event SetWithholdingFixed(address[] _investors, uint256 _withholding, uint256 _timestamp);
     event SetWallet(address indexed _oldWallet, address indexed _newWallet, uint256 _timestamp);
+    event UpdateDividendDates(uint256 indexed _dividendIndex, uint256 _maturity, uint256 _expiry);
 
     modifier validDividendIndex(uint256 _dividendIndex) {
         require(_dividendIndex < dividends.length, "Invalid dividend");
@@ -266,6 +267,21 @@ contract DividendCheckpoint is DividendCheckpointStorage, ICheckpoint, Module, P
      * @param _dividendIndex Dividend to withdraw from
      */
     function withdrawWithholding(uint256 _dividendIndex) external;
+
+    /**
+     * @notice Allows issuer to change maturity / expiry dates for dividends
+     * @param _dividendIndex Dividend to withdraw from
+     * @param _maturity updated maturity date
+     * @param _expiry updated expiry date
+     */
+    function updateDividendDates(uint256 _dividendIndex, uint256 _maturity, uint256 _expiry) onlyOwner {
+        require(_dividendIndex < dividends.length, "Invalid dividend");
+        require(_expiry > _maturity, "Expiry before maturity");
+        Dividend storage dividend = dividends[_dividendIndex];
+        dividend.expiry = _expiry;
+        dividend.maturity = _maturity;
+        emit UpdateDividendDates(_dividendIndex, _maturity, _expiry);
+    }
 
     /**
      * @notice Get static dividend data

--- a/contracts/modules/Checkpoint/DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/DividendCheckpoint.sol
@@ -294,6 +294,10 @@ contract DividendCheckpoint is DividendCheckpointStorage, ICheckpoint, Module, P
 
     /**
      * @notice Allows issuer to change maturity / expiry dates for dividends
+     * @dev NB - setting the maturity of a currently matured dividend to a future date
+     * @dev will effectively refreeze claims on that dividend until the new maturity date passes
+     * @ dev NB - setting the expiry date to a past date will mean no more payments can be pulled
+     * @dev or pushed out of a dividend
      * @param _dividendIndex Dividend to withdraw from
      * @param _maturity updated maturity date
      * @param _expiry updated expiry date

--- a/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/ERC20DividendCheckpoint.sol
@@ -241,12 +241,12 @@ contract ERC20DividendCheckpoint is ERC20DividendCheckpointStorage, DividendChec
         uint256 claimAfterWithheld = claim.sub(withheld);
         if (claimAfterWithheld > 0) {
             require(IERC20(dividendTokens[_dividendIndex]).transfer(_payee, claimAfterWithheld), "transfer failed");
-            if (withheld > 0) {
-                _dividend.totalWithheld = _dividend.totalWithheld.add(withheld);
-                _dividend.withheld[_payee] = withheld;
-            }
-            emit ERC20DividendClaimed(_payee, _dividendIndex, dividendTokens[_dividendIndex], claim, withheld);
         }
+        if (withheld > 0) {
+            _dividend.totalWithheld = _dividend.totalWithheld.add(withheld);
+            _dividend.withheld[_payee] = withheld;
+        }
+        emit ERC20DividendClaimed(_payee, _dividendIndex, dividendTokens[_dividendIndex], claim, withheld);
     }
 
     /**

--- a/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
+++ b/contracts/modules/Checkpoint/EtherDividendCheckpoint.sol
@@ -172,19 +172,17 @@ contract EtherDividendCheckpoint is DividendCheckpoint {
         (uint256 claim, uint256 withheld) = calculateDividend(_dividendIndex, _payee);
         _dividend.claimed[_payee] = true;
         uint256 claimAfterWithheld = claim.sub(withheld);
-        if (claimAfterWithheld > 0) {
-            /*solium-disable-next-line security/no-send*/
-            if (_payee.send(claimAfterWithheld)) {
-                _dividend.claimedAmount = _dividend.claimedAmount.add(claim);
-                if (withheld > 0) {
-                    _dividend.totalWithheld = _dividend.totalWithheld.add(withheld);
-                    _dividend.withheld[_payee] = withheld;
-                }
-                emit EtherDividendClaimed(_payee, _dividendIndex, claim, withheld);
-            } else {
-                _dividend.claimed[_payee] = false;
-                emit EtherDividendClaimFailed(_payee, _dividendIndex, claim, withheld);
+        /*solium-disable-next-line security/no-send*/
+        if (_payee.send(claimAfterWithheld)) {
+            _dividend.claimedAmount = _dividend.claimedAmount.add(claim);
+            if (withheld > 0) {
+                _dividend.totalWithheld = _dividend.totalWithheld.add(withheld);
+                _dividend.withheld[_payee] = withheld;
             }
+            emit EtherDividendClaimed(_payee, _dividendIndex, claim, withheld);
+        } else {
+            _dividend.claimed[_payee] = false;
+            emit EtherDividendClaimFailed(_payee, _dividendIndex, claim, withheld);
         }
     }
 

--- a/contracts/modules/Module.sol
+++ b/contracts/modules/Module.sol
@@ -57,24 +57,4 @@ contract Module is IModule, ModuleStorage {
         return true;
     }
 
-    /**
-    * @notice Reclaims ERC20Basic compatible tokens
-    * @dev We duplicate here due to the overriden owner & onlyOwner
-    * @param _tokenContract The address of the token contract
-    */
-    function reclaimERC20(address _tokenContract) external onlyOwner {
-        require(_tokenContract != address(0), "Invalid address");
-        IERC20 token = IERC20(_tokenContract);
-        uint256 balance = token.balanceOf(address(this));
-        require(token.transfer(msg.sender, balance), "Transfer failed");
-    }
-
-    /**
-    * @notice Reclaims ETH
-    * @dev We duplicate here due to the overriden owner & onlyOwner
-    */
-    function reclaimETH() external onlyOwner {
-        msg.sender.transfer(address(this).balance);
-    }
-
 }

--- a/contracts/modules/Module.sol
+++ b/contracts/modules/Module.sol
@@ -56,4 +56,25 @@ contract Module is IModule, ModuleStorage {
         require(polyToken.transferFrom(securityToken, Ownable(factory).owner(), _amount), "Unable to take fee");
         return true;
     }
+
+    /**
+    * @notice Reclaims ERC20Basic compatible tokens
+    * @dev We duplicate here due to the overriden owner & onlyOwner
+    * @param _tokenContract The address of the token contract
+    */
+    function reclaimERC20(address _tokenContract) external onlyOwner {
+        require(_tokenContract != address(0), "Invalid address");
+        IERC20 token = IERC20(_tokenContract);
+        uint256 balance = token.balanceOf(address(this));
+        require(token.transfer(msg.sender, balance), "Transfer failed");
+    }
+
+    /**
+    * @notice Reclaims ETH
+    * @dev We duplicate here due to the overriden owner & onlyOwner
+    */
+    function reclaimETH() external onlyOwner {
+        msg.sender.transfer(address(this).balance);
+    }
+
 }

--- a/contracts/modules/STO/STO.sol
+++ b/contracts/modules/STO/STO.sol
@@ -53,4 +53,24 @@ contract STO is ISTO, STOStorage, Module, Pausable  {
         emit SetFundRaiseTypes(_fundRaiseTypes);
     }
 
+    /**
+    * @notice Reclaims ERC20Basic compatible tokens
+    * @dev We duplicate here due to the overriden owner & onlyOwner
+    * @param _tokenContract The address of the token contract
+    */
+    function reclaimERC20(address _tokenContract) external onlyOwner {
+        require(_tokenContract != address(0), "Invalid address");
+        IERC20 token = IERC20(_tokenContract);
+        uint256 balance = token.balanceOf(address(this));
+        require(token.transfer(msg.sender, balance), "Transfer failed");
+    }
+
+    /**
+    * @notice Reclaims ETH
+    * @dev We duplicate here due to the overriden owner & onlyOwner
+    */
+    function reclaimETH() external onlyOwner {
+        msg.sender.transfer(address(this).balance);
+    }
+
 }

--- a/contracts/modules/STO/STO.sol
+++ b/contracts/modules/STO/STO.sol
@@ -19,18 +19,6 @@ contract STO is ISTO, STOStorage, Module, Pausable  {
     event SetFundRaiseTypes(FundRaiseType[] _fundRaiseTypes);
 
     /**
-    * @notice Reclaims ERC20Basic compatible tokens
-    * @dev We duplicate here due to the overriden owner & onlyOwner
-    * @param _tokenContract The address of the token contract
-    */
-    function reclaimERC20(address _tokenContract) external onlyOwner {
-        require(_tokenContract != address(0), "Invalid address");
-        IERC20 token = IERC20(_tokenContract);
-        uint256 balance = token.balanceOf(address(this));
-        require(token.transfer(msg.sender, balance), "Transfer failed");
-    }
-
-    /**
      * @notice Returns funds raised by the STO
      */
     function getRaised(FundRaiseType _fundRaiseType) public view returns (uint256) {

--- a/contracts/modules/STO/USDTieredSTO.sol
+++ b/contracts/modules/STO/USDTieredSTO.sol
@@ -277,7 +277,7 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
      * @notice Reserve address must be whitelisted to successfully finalize
      */
     function finalize() external onlyOwner {
-        require(!isFinalized, "STO is already finalized");
+        require(!isFinalized, "STO is finalized");
         isFinalized = true;
         uint256 tempReturned;
         uint256 tempSold;
@@ -305,7 +305,7 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
      * @param _accredited Array of bools specifying accreditation status
      */
     function changeAccredited(address[] _investors, bool[] _accredited) external onlyOwner {
-        require(_investors.length == _accredited.length, "Array length mismatch");
+        require(_investors.length == _accredited.length, "Array mismatch");
         for (uint256 i = 0; i < _investors.length; i++) {
             if (_accredited[i]) {
                 investors[_investors[i]].accredited = uint8(1);
@@ -324,7 +324,7 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
      */
     function changeNonAccreditedLimit(address[] _investors, uint256[] _nonAccreditedLimit) external onlyOwner {
         //nonAccreditedLimitUSDOverride
-        require(_investors.length == _nonAccreditedLimit.length, "Array length mismatch");
+        require(_investors.length == _nonAccreditedLimit.length, "Array mismatch");
         for (uint256 i = 0; i < _investors.length; i++) {
             investors[_investors[i]].nonAccreditedLimitUSDOverride = _nonAccreditedLimit[i];
             _addToInvestorsList(_investors[i]);
@@ -361,7 +361,7 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
      * @param _allowBeneficialInvestments Boolean to allow or disallow beneficial investments
      */
     function changeAllowBeneficialInvestments(bool _allowBeneficialInvestments) external onlyOwner {
-        require(_allowBeneficialInvestments != allowBeneficialInvestments, "Value unchanged");
+        require(_allowBeneficialInvestments != allowBeneficialInvestments);
         allowBeneficialInvestments = _allowBeneficialInvestments;
         emit SetAllowBeneficialInvestments(allowBeneficialInvestments);
     }
@@ -399,7 +399,7 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
         uint256 rate = getRate(FundRaiseType.ETH);
         uint256 initialMinted = getTokensMinted();
         (uint256 spentUSD, uint256 spentValue) = _buyTokens(_beneficiary, msg.value, rate, FundRaiseType.ETH);
-        require(getTokensMinted().sub(initialMinted) >= _minTokens, "Insufficient tokens minted");
+        require(getTokensMinted().sub(initialMinted) >= _minTokens, "Insufficient minted");
         // Modify storage
         investorInvested[_beneficiary][uint8(FundRaiseType.ETH)] = investorInvested[_beneficiary][uint8(FundRaiseType.ETH)].add(spentValue);
         fundsRaised[uint8(FundRaiseType.ETH)] = fundsRaised[uint8(FundRaiseType.ETH)].add(spentValue);
@@ -434,11 +434,11 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
     }
 
     function _buyWithTokens(address _beneficiary, uint256 _tokenAmount, FundRaiseType _fundRaiseType, uint256 _minTokens, IERC20 _token) internal {
-        require(_fundRaiseType == FundRaiseType.POLY || _fundRaiseType == FundRaiseType.SC, "Invalid raise type");
+        require(_fundRaiseType == FundRaiseType.POLY || _fundRaiseType == FundRaiseType.SC, "Invalid raise");
         uint256 initialMinted = getTokensMinted();
         uint256 rate = getRate(_fundRaiseType);
         (uint256 spentUSD, uint256 spentValue) = _buyTokens(_beneficiary, _tokenAmount, rate, _fundRaiseType);
-        require(getTokensMinted().sub(initialMinted) >= _minTokens, "Insufficient tokens minted");
+        require(getTokensMinted().sub(initialMinted) >= _minTokens, "Insufficient minted");
         // Modify storage
         investorInvested[_beneficiary][uint8(_fundRaiseType)] = investorInvested[_beneficiary][uint8(_fundRaiseType)].add(spentValue);
         fundsRaised[uint8(_fundRaiseType)] = fundsRaised[uint8(_fundRaiseType)].add(spentValue);
@@ -552,12 +552,12 @@ contract USDTieredSTO is USDTieredSTOStorage, STO, ReentrancyGuard {
         require(_investmentValue > 0, "No funds were sent");
 
         // Check for minimum investment
-        require(investedUSD.add(investorInvestedUSD[_beneficiary]) >= minimumInvestmentUSD, "Total investment < minimumInvestmentUSD");
+        require(investedUSD.add(investorInvestedUSD[_beneficiary]) >= minimumInvestmentUSD, "investment < minimumInvestmentUSD");
         netInvestedUSD = investedUSD;
         // Check for non-accredited cap
         if (investors[_beneficiary].accredited == uint8(0)) {
             uint256 investorLimitUSD = (investors[_beneficiary].nonAccreditedLimitUSDOverride == 0) ? nonAccreditedLimitUSD : investors[_beneficiary].nonAccreditedLimitUSDOverride;
-            require(investorInvestedUSD[_beneficiary] < investorLimitUSD, "Over Non-accredited investor limit");
+            require(investorInvestedUSD[_beneficiary] < investorLimitUSD, "Over investor limit");
             if (investedUSD.add(investorInvestedUSD[_beneficiary]) > investorLimitUSD)
                 netInvestedUSD = investorLimitUSD.sub(investorInvestedUSD[_beneficiary]);
         }

--- a/test/b_capped_sto.js
+++ b/test/b_capped_sto.js
@@ -888,6 +888,8 @@ contract("CappedSTO", accounts => {
             it("should reclaim ETH and ERC20 from STO", async () => {
                 let initialIssuerETH = BigNumber(await web3.eth.getBalance(token_owner));
                 let initialIssuerPOLY = BigNumber(await I_PolyToken.balanceOf(token_owner));
+                await catchRevert(I_DummySTO.reclaimERC20(I_PolyToken.address, {from: account_polymath, gasPrice: 0}));
+                await catchRevert(I_DummySTO.reclaimETH( {from: account_polymath, gasPrice: 0}));
                 let tx = await I_DummySTO.reclaimERC20(I_PolyToken.address, {from: token_owner, gasPrice: 0});
                 let tx2 = await I_DummySTO.reclaimETH({from: token_owner, gasPrice: 0});
                 let finalIssuerETH = BigNumber(await web3.eth.getBalance(token_owner));

--- a/test/b_capped_sto.js
+++ b/test/b_capped_sto.js
@@ -2,11 +2,12 @@ import latestTime from "./helpers/latestTime";
 import { duration, ensureException, promisifyLogWatch, latestBlock } from "./helpers/utils";
 import { takeSnapshot, increaseTime, revertToSnapshot } from "./helpers/time";
 import { encodeModuleCall } from "./helpers/encodeCall";
-import { setUpPolymathNetwork, deployGPMAndVerifyed } from "./helpers/createInstances";
+import { setUpPolymathNetwork, deployGPMAndVerifyed, deployDummySTOAndVerifyed } from "./helpers/createInstances";
 import { catchRevert } from "./helpers/exceptions";
 
 const CappedSTOFactory = artifacts.require("./CappedSTOFactory.sol");
 const CappedSTO = artifacts.require("./CappedSTO.sol");
+const DummySTO = artifacts.require("./DummySTO.sol");
 const SecurityToken = artifacts.require("./SecurityToken.sol");
 const GeneralTransferManager = artifacts.require("./GeneralTransferManager");
 const GeneralPermissionManager = artifacts.require("./GeneralPermissionManager");
@@ -54,6 +55,7 @@ contract("CappedSTO", accounts => {
     let I_SecurityToken_POLY;
     let I_CappedSTO_Array_ETH = [];
     let I_CappedSTO_Array_POLY = [];
+    let I_DummySTO;
     let I_PolyToken;
     let I_PolymathRegistry;
     let I_STRProxied;
@@ -441,7 +443,7 @@ contract("CappedSTO", accounts => {
         });
 
         it("Should restrict to buy tokens after hiting the cap in second tx first tx pass", async () => {
-            
+
 
             // Fallback transaction
             await web3.eth.sendTransaction({
@@ -850,6 +852,56 @@ contract("CappedSTO", accounts => {
             });
         });
 
+        describe("Check that we can reclaim ETH and ERC20 tokens from an STO", async () => {
+            //xxx
+            it("should attach a dummy STO", async () => {
+                let I_DummySTOFactory;
+                [I_DummySTOFactory] = await deployDummySTOAndVerifyed(account_polymath, I_MRProxied, I_PolyToken.address, 0);
+                const DummySTOParameters = ["uint256", "uint256", "uint256", "string"];
+                let startTime = latestTime() + duration.days(1);
+                let endTime = startTime + duration.days(30);
+                const cap = web3.utils.toWei("10000");
+                const dummyBytesSig = encodeModuleCall(DummySTOParameters, [startTime, endTime, cap, "Hello"]);
+                const tx = await I_SecurityToken_ETH.addModule(I_DummySTOFactory.address, dummyBytesSig, maxCost, 0, { from: token_owner });
+                assert.equal(tx.logs[2].args._types[0], stoKey, `Wrong module type added`);
+                assert.equal(
+                    web3.utils.hexToString(tx.logs[2].args._name),
+                    "DummySTO",
+                    `Wrong STO module added`
+                );
+                I_DummySTO = DummySTO.at(tx.logs[2].args._module);
+            });
+            it("should send some funds and ERC20 to the DummySTO", async () => {
+                let tx = await web3.eth.sendTransaction({
+                    from: account_investor1,
+                    to: I_DummySTO.address,
+                    gas: 2100000,
+                    value: web3.utils.toWei("1", "ether")
+                });
+                let dummyETH = BigNumber(await web3.eth.getBalance(I_DummySTO.address));
+                assert.equal(dummyETH.toNumber(), web3.utils.toWei("1", "ether"));
+                await I_PolyToken.getTokens(web3.utils.toWei("2", "ether"), I_DummySTO.address);
+                let dummyPOLY = BigNumber(await I_PolyToken.balanceOf(I_DummySTO.address));
+                assert.equal(dummyPOLY.toNumber(), web3.utils.toWei("2", "ether"));
+            });
+
+            it("should reclaim ETH and ERC20 from STO", async () => {
+                let initialIssuerETH = BigNumber(await web3.eth.getBalance(token_owner));
+                let initialIssuerPOLY = BigNumber(await I_PolyToken.balanceOf(token_owner));
+                let tx = await I_DummySTO.reclaimERC20(I_PolyToken.address, {from: token_owner, gasPrice: 0});
+                let tx2 = await I_DummySTO.reclaimETH({from: token_owner, gasPrice: 0});
+                let finalIssuerETH = BigNumber(await web3.eth.getBalance(token_owner));
+                let finalIssuerPOLY = BigNumber(await I_PolyToken.balanceOf(token_owner));
+                assert.equal(finalIssuerETH.sub(initialIssuerETH).toNumber(), web3.utils.toWei("1", "ether"));
+                assert.equal(finalIssuerPOLY.sub(initialIssuerPOLY).toNumber(), web3.utils.toWei("2", "ether"));
+                let dummyETH = BigNumber(await web3.eth.getBalance(I_DummySTO.address));
+                assert.equal(dummyETH.toNumber(), 0);
+                let dummyPOLY = BigNumber(await I_PolyToken.balanceOf(I_DummySTO.address));
+                assert.equal(dummyPOLY.toNumber(), 0);
+            });
+        });
+
+
         describe("Test cases for the CappedSTOFactory", async () => {
             it("should get the exact details of the factory", async () => {
                 assert.equal((await I_CappedSTOFactory.getSetupCost.call()).toNumber(), cappedSTOSetupCost);
@@ -996,7 +1048,7 @@ contract("CappedSTO", accounts => {
         it("Should successfully invest in second STO", async () => {
             const polyToInvest = 1000;
             const stToReceive = (polyToInvest * P_rate)/Math.pow(10, 18);
-            
+
             await I_PolyToken.getTokens(polyToInvest * Math.pow(10, 18), account_investor3);
 
             let tx = await I_GeneralTransferManager.modifyWhitelist(account_investor3, P_fromTime, P_toTime, P_expiryTime, true, {

--- a/test/f_ether_dividends.js
+++ b/test/f_ether_dividends.js
@@ -363,6 +363,10 @@ contract("EtherDividendCheckpoint", accounts => {
             assert.equal(issuerBalanceAfter.sub(issuerBalance).toNumber(), web3.utils.toWei("0", "ether"));
         });
 
+        it("Set withholding tax of 100% on investor 2", async () => {
+            await I_EtherDividendCheckpoint.setWithholdingFixed([account_investor2], BigNumber(100 * 10 ** 16), { from: token_owner });
+        });
+
         it("Buy some tokens for account_temp (1 ETH)", async () => {
             // Add the Investor in to the whitelist
 
@@ -486,12 +490,13 @@ contract("EtherDividendCheckpoint", accounts => {
             let investor1BalanceAfter1 = new BigNumber(await web3.eth.getBalance(account_investor1));
             let investor2BalanceAfter1 = new BigNumber(await web3.eth.getBalance(account_investor2));
             let investor3BalanceAfter1 = new BigNumber(await web3.eth.getBalance(account_investor3));
-            await I_EtherDividendCheckpoint.pushDividendPayment(2, 0, 10, { from: token_owner });
+            let _blockNo = latestBlock();
+            let tx = await I_EtherDividendCheckpoint.pushDividendPayment(2, 0, 10, { from: token_owner });
             let investor1BalanceAfter2 = new BigNumber(await web3.eth.getBalance(account_investor1));
             let investor2BalanceAfter2 = new BigNumber(await web3.eth.getBalance(account_investor2));
             let investor3BalanceAfter2 = new BigNumber(await web3.eth.getBalance(account_investor3));
             assert.equal(investor1BalanceAfter2.sub(investor1BalanceAfter1).toNumber(), 0);
-            assert.equal(investor2BalanceAfter2.sub(investor2BalanceAfter1).toNumber(), web3.utils.toWei("2.4", "ether"));
+            assert.equal(investor2BalanceAfter2.sub(investor2BalanceAfter1).toNumber(), 0);
             assert.equal(investor3BalanceAfter2.sub(investor3BalanceAfter1).toNumber(), 0);
             //Check fully claimed
             assert.equal((await I_EtherDividendCheckpoint.dividends(2))[5].toNumber(), web3.utils.toWei("11", "ether"));
@@ -501,7 +506,7 @@ contract("EtherDividendCheckpoint", accounts => {
             let issuerBalance = new BigNumber(await web3.eth.getBalance(wallet));
             await I_EtherDividendCheckpoint.withdrawWithholding(2, { from: token_owner, gasPrice: 0 });
             let issuerBalanceAfter = new BigNumber(await web3.eth.getBalance(wallet));
-            assert.equal(issuerBalanceAfter.sub(issuerBalance).toNumber(), web3.utils.toWei("0.6", "ether"));
+            assert.equal(issuerBalanceAfter.sub(issuerBalance).toNumber(), web3.utils.toWei("3", "ether"));
         });
 
         it("Investor 2 transfers 1 ETH of his token balance to investor 1", async () => {
@@ -531,7 +536,7 @@ contract("EtherDividendCheckpoint", accounts => {
             );
         });
 
-        it("Create another new dividend with bad expirty - fails", async () => {
+        it("Create another new dividend with bad expiry - fails", async () => {
             let maturity = latestTime() - duration.days(5);
             let expiry = latestTime() - duration.days(2);
             await catchRevert(
@@ -648,7 +653,7 @@ contract("EtherDividendCheckpoint", accounts => {
             assert.equal(dividendAmount1[0].toNumber(), web3.utils.toWei("0", "ether"));
             assert.equal(dividendAmount1[1].toNumber(), web3.utils.toWei("0", "ether"));
             assert.equal(dividendAmount2[0].toNumber(), web3.utils.toWei("2", "ether"));
-            assert.equal(dividendAmount2[1].toNumber(), web3.utils.toWei("0.4", "ether"));
+            assert.equal(dividendAmount2[1].toNumber(), web3.utils.toWei("2", "ether"));
             assert.equal(dividendAmount3[0].toNumber(), web3.utils.toWei("7", "ether"));
             assert.equal(dividendAmount3[1].toNumber(), web3.utils.toWei("0", "ether"));
             assert.equal(dividendAmount_temp[0].toNumber(), web3.utils.toWei("1", "ether"));
@@ -666,7 +671,7 @@ contract("EtherDividendCheckpoint", accounts => {
             let investor3BalanceAfter1 = new BigNumber(await web3.eth.getBalance(account_investor3));
             let tempBalanceAfter1 = new BigNumber(await web3.eth.getBalance(account_temp));
             assert.equal(investor1BalanceAfter1.sub(investor1Balance).toNumber(), 0);
-            assert.equal(investor2BalanceAfter1.sub(investor2Balance).toNumber(), web3.utils.toWei("1.6", "ether"));
+            assert.equal(investor2BalanceAfter1.sub(investor2Balance).toNumber(), 0);
             assert.equal(investor3BalanceAfter1.sub(investor3Balance).toNumber(), 0);
             assert.equal(tempBalanceAfter1.sub(tempBalance).toNumber(), 0);
         });
@@ -769,7 +774,7 @@ contract("EtherDividendCheckpoint", accounts => {
             let tokenBalanceAfter = new BigNumber(await web3.eth.getBalance(I_PolyToken.address));
 
             assert.equal(investor1BalanceAfter.sub(investor1BalanceBefore).toNumber(), web3.utils.toWei("1", "ether"));
-            assert.equal(investor2BalanceAfter.sub(investor2BalanceBefore).toNumber(), web3.utils.toWei("1.6", "ether"));
+            assert.equal(investor2BalanceAfter.sub(investor2BalanceBefore).toNumber(), 0);
             assert.equal(investor3BalanceAfter.sub(investor3BalanceBefore).toNumber(), web3.utils.toWei("7", "ether"));
             assert.equal(tempBalanceAfter.sub(tempBalanceBefore).toNumber(), web3.utils.toWei("1", "ether"));
             assert.equal(tokenBalanceAfter.sub(tokenBalanceBefore).toNumber(), web3.utils.toWei("0", "ether"));

--- a/test/p_usd_tiered_sto.js
+++ b/test/p_usd_tiered_sto.js
@@ -2197,7 +2197,7 @@ contract("USDTieredSTO", accounts => {
             let investorStatus = await I_USDTieredSTO_Array[stoId].investors.call(NONACCREDITED1);
             console.log("Current limit: " + investorStatus[2].toNumber());
             let totalStatus = await I_USDTieredSTO_Array[stoId].getAccreditedData.call();
-            
+
             assert.equal(totalStatus[0][0], NONACCREDITED1, "Account match");
             assert.equal(totalStatus[0][1], ACCREDITED1, "Account match");
             assert.equal(totalStatus[1][0], false, "Account match");
@@ -4665,6 +4665,8 @@ contract("USDTieredSTO", accounts => {
             await I_USDOracle.changePrice(USDETH, { from: POLYMATH });
             await I_POLYOracle.changePrice(USDPOLY, { from: POLYMATH });
         });
+
+        it("should allow issuer to retrieve funds", async () => {
     });
 
     describe("Test getter functions", async () => {

--- a/test/p_usd_tiered_sto.js
+++ b/test/p_usd_tiered_sto.js
@@ -4666,7 +4666,6 @@ contract("USDTieredSTO", accounts => {
             await I_POLYOracle.changePrice(USDPOLY, { from: POLYMATH });
         });
 
-        it("should allow issuer to retrieve funds", async () => {
     });
 
     describe("Test getter functions", async () => {


### PR DESCRIPTION
  - move DummySTO (and associated factory) to the mocks folder and add a payable fallback function to test reclaiming ETH & ERC20.
  - add a `reclaimETH` function to `STO.sol` to allow any ETH that may become locked in an STO contract to be reclaimed by the issuer.
  - make Dividend contracts (ERC20 & Ether) pausable, with pulling dividends only possible when the contract is not paused. All other functions do not depend on being paused, but are open only to authorised addresses.
  - allow the issuer to update maturity & expiry dates on existing dividends. This can be used to postpone a dividend (pushing back the maturity) or make a dividend reclaimable (making expiry earlier than now) or to correct mistakes when originally creating the dividend. NB - changing these dates may cause a dividend to no longer be valid for payments (e.g. setting it's expiry to be in the past, or it's maturity to be in the future).
  - small refactor to `validDividendIndex` to reduce contract size
  - add `reclaimETH` and `reclaimERC20` to Dividend contracts (ERC20 & Ether). This allows (in an emergency) any funds to be pulled out of a dividend contract by the issuer.
  - fix bug in `_payDividend` Dividend function (ERC20 & Ether) when withholding tax is 100%
  - improve test cases (add a test for reclaiming ETH & ERC20 tokens from STO and 100% withholding tax in Dividends, and for pausing / updating dates / reclaiming ETH / ERC20 from Dividend contracts)