### PR TITLE
Refresh / Upgrade tokens

### DIFF
--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -553,8 +553,7 @@ contract SecurityTokenRegistry is EternalStorage, Proxy {
         require(bytes(_name).length > 0 && bytes(_ticker).length > 0, "Bad ticker");
         require(_treasuryWallet != address(0), "0x0 not allowed");
         string memory ticker = Util.upper(_ticker);
-        bytes32 statusKey = Encoder.getKey("registeredTickers_status", ticker);
-        require(getBoolValue(statusKey), "not deployed");
+        require(_tickerStatus(ticker), "not deployed");
         address st = getAddressValue(Encoder.getKey("tickerToSecurityToken", ticker));
         address stOwner = IOwnable(st).owner();
         require(msg.sender == stOwner, "Unauthroized");

--- a/contracts/interfaces/ISecurityToken.sol
+++ b/contracts/interfaces/ISecurityToken.sol
@@ -463,4 +463,9 @@ interface ISecurityToken {
      * @return bool `true` signifies the minting is allowed. While `false` denotes the end of minting
      */
     function isIssuable() external view returns (bool);
+
+    /**
+    * @notice Returns if transfers are currently frozen or not
+    */
+    function transfersFrozen() external view returns (bool);
 }


### PR DESCRIPTION
This will allow Issuers to regenerate a fresh security token in the same ticker name if they want to do an upgrade or want to reset the data.