### PR TITLE
Coverage memory limit increased

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -91,7 +91,7 @@ fi
 if [ "$COVERAGE" = true ]; then
   curl -o node_modules/solidity-coverage/lib/app.js https://raw.githubusercontent.com/maxsam4/solidity-coverage/relative-path/lib/app.js
   curl -o node_modules/solidity-parser-sc/build/parser.js https://raw.githubusercontent.com/maxsam4/solidity-parser/solidity-0.5/build/parser.js
-  node_modules/.bin/solidity-coverage
+  node --max_old_space_size=3500 node_modules/.bin/solidity-coverage
   if [ "$CIRCLECI" = true ]; then
     cat coverage/lcov.info | node_modules/.bin/coveralls || echo 'Failed to report coverage to Coveralls'
   fi


### PR DESCRIPTION
Coverage was running out of memory since yesterday. I have raised the limit from 1.7gb (default) to 3.5gb.
CircleCI provides us with 4gb of ram and I decided to keep 0.5gb safely away for ganache and other task.