### PR TITLE
fix up ABI to make compatible with openzepplin ABI change

### DIFF
--- a/CLI/commands/helpers/contract_abis.js
+++ b/CLI/commands/helpers/contract_abis.js
@@ -53,7 +53,7 @@ try {
     iSTOABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ISTO.json`).toString()).abi
     iTransferManagerABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ITransferManager.json`).toString()).abi
     moduleFactoryABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ModuleFactory.json`).toString()).abi;
-    erc20ABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/DetailedERC20.json`).toString()).abi;
+    erc20ABI = JSON.parse(require('fs').readFileSync(`${__dirname}/../../../build/contracts/ERC20Detailed.json`).toString()).abi;
 } catch (err) {
     console.log('\x1b[31m%s\x1b[0m', "Couldn't find contracts' artifacts. Make sure you ran truffle compile first");
     throw err;


### PR DESCRIPTION
This fixes up the ABI to fix compile issue with the renaming of
openzepplin 2.1.0


### Please check if the PR fulfills these requirements
- [ ] The commit message follows our Submission guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 

Allows branch to compile

### What is the current behavior? 

CLI fails to compile


### What is the new behavior?

CLI compiles

### Does this PR introduce a breaking change?
No


### Any Other information:
