### PR TITLE
Shared Whitelist TM

### DIFF
--- a/contracts/modules/Experimental/TransferManager/SWTM/ShareWhitelistTransferManagerFactory.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/ShareWhitelistTransferManagerFactory.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.5.0;
+
+import "./SharedWhitelistTransferManagerProxy.sol";
+import "../../../UpgradableModuleFactory.sol";
+
+/**
+ * @title Factory for deploying SharedWhitelistTransferManager module
+ */
+contract SharedWhitelistTransferManagerFactory is UpgradableModuleFactory {
+
+    /**
+     * @notice Constructor
+     * @param _setupCost Setup cost of the module
+     * @param _usageCost Usage cost of the module
+     * @param _logicContract Contract address that contains the logic related to `description`
+     * @param _polymathRegistry Address of the Polymath registry
+     * @param _isCostInPoly true = cost in Poly, false = USD
+     */
+    constructor (
+        uint256 _setupCost,
+        uint256 _usageCost,
+        address _logicContract,
+        address _polymathRegistry,
+        bool _isCostInPoly
+    )
+        public
+        UpgradableModuleFactory("3.0.0", _setupCost, _usageCost, _logicContract, _polymathRegistry, _isCostInPoly)
+    {
+        name = "SharedWhitelistTransferManager";
+        title = "Share Whitelist Transfer Manager";
+        description = "Manage transfers using a shared time based whitelist";
+        typesData.push(2);
+        tagsData.push("Shared Whitelist");
+        tagsData.push("Transfer Restriction");
+        compatibleSTVersionRange["lowerBound"] = VersionUtils.pack(uint8(3), uint8(0), uint8(0));
+        compatibleSTVersionRange["upperBound"] = VersionUtils.pack(uint8(3), uint8(0), uint8(0));
+    }
+
+    /**
+     * @notice Used to launch the Module with the help of factory
+     * @return address Contract address of the Module
+     */
+    function deploy(
+        bytes calldata _data
+    )
+        external
+        returns(address)
+    {
+        address sharedWhitelistTransferManager = address(new SharedWhitelistTransferManagerProxy(logicContracts[latestUpgrade].version, msg.sender, IPolymathRegistry(polymathRegistry).getAddress("PolyToken"), logicContracts[latestUpgrade].logicContract));
+        _initializeModule(sharedWhitelistTransferManager, _data);
+        return sharedWhitelistTransferManager;
+    }
+
+}

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
@@ -1,35 +1,18 @@
 pragma solidity ^0.5.0;
 
-import "../../../TransferManager/TransferManager.sol";
-import "../../../../libraries/Encoder.sol";
-import "../../../../libraries/VersionUtils.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+import "../../../TransferManager/BaseWhitelistTransferManager.sol";
+import "../../../TransferManager/BaseWhitelistTransferManagerStorage.sol";
 import "./SharedWhitelistTransferManagerStorage.sol";
 
 /**
  * @title Transfer Manager module that uses a shared whitelist for transfer validation functionality
  */
-contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage, TransferManager {
+contract SharedWhitelistTransferManager is BaseWhitelistTransferManagerStorage, SharedWhitelistTransferManagerStorage, BaseWhitelistTransferManager {
     using SafeMath for uint256;
     using ECDSA for bytes32;
 
     // Emit when whitelist address is changed
     event WhitelistDataStoreChanged(address indexed _oldDataStore, address indexed _newDataStore);
-
-    // Emit when Issuance address get changed
-    event ChangeIssuanceAddress(address _issuanceAddress);
-
-    // Emit when investor details get modified related to their whitelisting
-    event ChangeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter);
-
-    event ModifyTransferRequirements(
-        TransferType indexed _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
-    );
 
     /**
      * @notice Constructor
@@ -72,30 +55,7 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
     }
 
     /**
-     * @notice Used to change the default times used when canSendAfter / canReceiveAfter are zero
-     * @param _defaultCanSendAfter default for zero canSendAfter
-     * @param _defaultCanReceiveAfter default for zero canReceiveAfter
-     */
-    function changeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter) public withPerm(ADMIN) {
-        /* 0 values are also allowed as they represent that the Issuer
-           does not want a default value for these variables.
-           0 is also the default value of these variables */
-        defaults.canSendAfter = _defaultCanSendAfter;
-        defaults.canReceiveAfter = _defaultCanReceiveAfter;
-        emit ChangeDefaults(_defaultCanSendAfter, _defaultCanReceiveAfter);
-    }
-
-    /**
-     * @notice Used to change the Issuance Address
-     * @param _issuanceAddress new address for the issuance
-     */
-    function changeIssuanceAddress(address _issuanceAddress) public withPerm(ADMIN) {
-        // address(0x0) is also a valid value and in most cases, the address that issues tokens is 0x0.
-        issuanceAddress = _issuanceAddress;
-        emit ChangeIssuanceAddress(_issuanceAddress);
-    }
-
-    /**
+     * @dev overrides abstract function from base contract
      * @notice Default implementation of verifyTransfer used by SecurityToken
      * If the transfer request comes from the STO, it only checks that the investor is in the whitelist
      * If the transfer request comes from a token holder, it checks that:
@@ -122,187 +82,6 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
         return success;
     }
 
-    /**
-     * @notice Default implementation of verifyTransfer used by SecurityToken
-     * @param _from Address of the sender
-     * @param _to Address of the receiver
-    */
-    function verifyTransfer(
-        address _from,
-        address _to,
-        uint256 /*_amount*/,
-        bytes memory /* _data */
-    )
-        public
-        view
-        returns(Result, bytes32)
-    {
-        return _verifyTransfer(_from, _to);
-    }
-
-    function _verifyTransfer(
-        address _from,
-        address _to
-    )
-        internal
-        view
-        returns(Result, bytes32)
-    {
-        if (!paused) {
-            TransferRequirements memory txReq;
-            uint64 canSendAfter;
-            uint64 fromExpiry;
-            uint64 toExpiry;
-            uint64 canReceiveAfter;
-
-            if (_from == issuanceAddress) {
-                txReq = transferRequirements[uint8(TransferType.ISSUANCE)];
-            } else if (_to == address(0)) {
-                txReq = transferRequirements[uint8(TransferType.REDEMPTION)];
-            } else {
-                txReq = transferRequirements[uint8(TransferType.GENERAL)];
-            }
-
-            (canSendAfter, fromExpiry, canReceiveAfter, toExpiry) = _getValuesForTransfer(_from, _to);
-
-            if ((txReq.fromValidKYC && !_validExpiry(fromExpiry)) || (txReq.toValidKYC && !_validExpiry(toExpiry))) {
-                return (Result.NA, bytes32(0));
-            }
-
-            (canSendAfter, canReceiveAfter) = _adjustTimes(canSendAfter, canReceiveAfter);
-
-            if ((txReq.fromRestricted && !_validLockTime(canSendAfter)) || (txReq.toRestricted && !_validLockTime(canReceiveAfter))) {
-                return (Result.NA, bytes32(0));
-            }
-
-            return (Result.VALID, getAddressBytes32());
-        }
-        return (Result.NA, bytes32(0));
-    }
-
-    /**
-    * @notice Modifies the successful checks required for a transfer to be deemed valid.
-    * @param _transferType Type of transfer (0 = General, 1 = Issuance, 2 = Redemption)
-    * @param _fromValidKYC Defines if KYC is required for the sender
-    * @param _toValidKYC Defines if KYC is required for the receiver
-    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
-    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
-    */
-    function modifyTransferRequirements(
-        TransferType _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
-    ) public withPerm(ADMIN) {
-        _modifyTransferRequirements(
-            _transferType,
-            _fromValidKYC,
-            _toValidKYC,
-            _fromRestricted,
-            _toRestricted
-        );
-    }
-
-    /**
-    * @notice Modifies the successful checks required for transfers.
-    * @param _transferTypes Types of transfer (0 = General, 1 = Issuance, 2 = Redemption)
-    * @param _fromValidKYC Defines if KYC is required for the sender
-    * @param _toValidKYC Defines if KYC is required for the receiver
-    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
-    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
-    */
-    function modifyTransferRequirementsMulti(
-        TransferType[] memory _transferTypes,
-        bool[] memory _fromValidKYC,
-        bool[] memory _toValidKYC,
-        bool[] memory _fromRestricted,
-        bool[] memory _toRestricted
-    ) public withPerm(ADMIN) {
-        require(
-            _transferTypes.length == _fromValidKYC.length &&
-            _fromValidKYC.length == _toValidKYC.length &&
-            _toValidKYC.length == _fromRestricted.length &&
-            _fromRestricted.length == _toRestricted.length,
-            "Mismatched input lengths"
-        );
-
-        for (uint256 i = 0; i <  _transferTypes.length; i++) {
-            _modifyTransferRequirements(
-                _transferTypes[i],
-                _fromValidKYC[i],
-                _toValidKYC[i],
-                _fromRestricted[i],
-                _toRestricted[i]
-            );
-        }
-    }
-
-    function _modifyTransferRequirements(
-        TransferType _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
-    ) internal {
-        transferRequirements[uint8(_transferType)] =
-            TransferRequirements(
-                _fromValidKYC,
-                _toValidKYC,
-                _fromRestricted,
-                _toRestricted
-            );
-
-        emit ModifyTransferRequirements(
-            _transferType,
-            _fromValidKYC,
-            _toValidKYC,
-            _fromRestricted,
-            _toRestricted
-        );
-    }
-
-    /**
-     * @notice Internal function used to check whether the KYC of investor is valid
-     * @param _expiryTime Expiry time of the investor
-     */
-    function _validExpiry(uint64 _expiryTime) internal view returns(bool valid) {
-        if (_expiryTime >= uint64(now)) /*solium-disable-line security/no-block-members*/
-            valid = true;
-    }
-
-    /**
-     * @notice Internal function used to check whether the lock time of investor is valid
-     * @param _lockTime Lock time of the investor
-     */
-    function _validLockTime(uint64 _lockTime) internal view returns(bool valid) {
-        if (_lockTime <= uint64(now)) /*solium-disable-line security/no-block-members*/
-            valid = true;
-    }
-
-    /**
-     * @notice Internal function to adjust times using default values
-     */
-    function _adjustTimes(uint64 _canSendAfter, uint64 _canReceiveAfter) internal view returns(uint64, uint64) {
-        if (_canSendAfter == 0) {
-            _canSendAfter = defaults.canSendAfter;
-        }
-        if (_canReceiveAfter == 0) {
-            _canReceiveAfter = defaults.canReceiveAfter;
-        }
-        return (_canSendAfter, _canReceiveAfter);
-    }
-
-    function _isExistingInvestor(address _investor, IDataStore dataStore) internal view returns(bool) {
-        uint256 data = dataStore.getUint256(_getKey(WHITELIST, _investor));
-        //extracts `added` from packed `_whitelistData`
-        return uint8(data) == 0 ? false : true;
-    }
-
-    function _getKey(bytes32 _key1, address _key2) internal pure returns(bytes32) {
-        return bytes32(keccak256(abi.encodePacked(_key1, _key2)));
-    }
-
     function _getKYCValues(address _investor) internal view returns(
         uint64 canSendAfter,
         uint64 canReceiveAfter,
@@ -314,6 +93,9 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
         (canSendAfter, canReceiveAfter, expiryTime, added)  = VersionUtils.unpackKYC(data);
     }
 
+    /**
+     * @dev overrides abstract function from base contract
+     */
     function _getValuesForTransfer(address _from, address _to) internal view returns(uint64 canSendAfter, uint64 fromExpiry, uint64 canReceiveAfter, uint64 toExpiry) {
         (canSendAfter, , fromExpiry, ) = _getKYCValues(_from);
         (, canReceiveAfter, toExpiry, ) = _getKYCValues(_to);
@@ -327,9 +109,9 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
         return whitelistDataStore.getAddressArrayLength(INVESTORSKEY);
     }
 
-
     /**
      * @dev Returns list of all investors
+     * @dev overrides abstract function from base contract
      */
     function getAllInvestors() public view returns(address[] memory investors) {
         investors = whitelistDataStore.getAddressArray(INVESTORSKEY);
@@ -337,57 +119,22 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
 
     /**
      * @dev Returns list of investors in a range
+     * @dev overrides abstract function from base contract
      */
     function getInvestors(uint256 _fromIndex, uint256 _toIndex) public view returns(address[] memory investors) {
         investors = whitelistDataStore.getAddressArrayElements(INVESTORSKEY, _fromIndex, _toIndex);
     }
 
-    function getAllInvestorFlags() public view returns(address[] memory investors, uint256[] memory flags) {
-        investors = getAllInvestors();
-        flags = new uint256[](investors.length);
-        for (uint256 i = 0; i < investors.length; i++) {
-            flags[i] = _getInvestorFlags(investors[i]);
-        }
-    }
-
-    function getInvestorFlag(address _investor, uint8 _flag) public view returns(bool value) {
-        uint256 flag = (_getInvestorFlags(_investor) >> _flag) & ONE;
-        value = flag > 0 ? true : false;
-    }
-
-    function getInvestorFlags(address _investor) public view returns(uint256 flags) {
-        flags = _getInvestorFlags(_investor);
-    }
-
-    function _getInvestorFlags(address _investor) public view returns(uint256 flags) {
+    /**
+     * @dev overrides abstract function from base contract
+     */
+    function _getInvestorFlags(address _investor) internal view returns(uint256 flags) {
         flags = whitelistDataStore.getUint256(_getKey(INVESTORFLAGS, _investor));
     }
 
     /**
-     * @dev Returns list of all investors data
+     * @dev overrides abstract function from base contract
      */
-    function getAllKYCData() external view returns(
-        address[] memory investors,
-        uint256[] memory canSendAfters,
-        uint256[] memory canReceiveAfters,
-        uint256[] memory expiryTimes
-    ) {
-        investors = getAllInvestors();
-        (canSendAfters, canReceiveAfters, expiryTimes) = _kycData(investors);
-        return (investors, canSendAfters, canReceiveAfters, expiryTimes);
-    }
-
-    /**
-     * @dev Returns list of specified investors data
-     */
-    function getKYCData(address[] calldata _investors) external view returns(
-        uint256[] memory,
-        uint256[] memory,
-        uint256[] memory
-    ) {
-        return _kycData(_investors);
-    }
-
     function _kycData(address[] memory _investors) internal view returns(
         uint256[] memory,
         uint256[] memory,
@@ -400,15 +147,6 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
             (canSendAfters[i], canReceiveAfters[i], expiryTimes[i], ) = _getKYCValues(_investors[i]);
         }
         return (canSendAfters, canReceiveAfters, expiryTimes);
-    }
-
-    /**
-     * @notice Return the permissions flag that are associated with general trnasfer manager
-     */
-    function getPermissions() public view returns(bytes32[] memory) {
-        bytes32[] memory allPermissions = new bytes32[](1);
-        allPermissions[0] = ADMIN;
-        return allPermissions;
     }
 
     /**
@@ -427,10 +165,6 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
             return currentBalance;
         else
             return 0;
-    }
-
-    function getAddressBytes32() public view returns(bytes32) {
-        return bytes32(uint256(address(this)) << 96);
     }
 
 }

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.0;
 
 import "../../../TransferManager/BaseWhitelistTransferManager.sol";
-import "../../../TransferManager/BaseWhitelistTransferManagerStorage.sol";
 import "./SharedWhitelistTransferManagerStorage.sol";
 
 /**

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
@@ -1,0 +1,420 @@
+pragma solidity ^0.5.0;
+
+import "../../../TransferManager/TransferManager.sol";
+import "../../../../libraries/Encoder.sol";
+import "../../../../libraries/VersionUtils.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+import "./SharedWhitelistTransferManagerStorage.sol";
+
+/**
+ * @title Transfer Manager module that uses a shared whitelist for transfer validation functionality
+ */
+contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage, TransferManager {
+    using SafeMath for uint256;
+    using ECDSA for bytes32;
+
+    // Emit when whitelist address is changed
+    event WhitelistDataStoreChanged(address indexed _oldDataStore, address indexed _newDataStore);
+
+    // Emit when Issuance address get changed
+    event ChangeIssuanceAddress(address _issuanceAddress);
+
+    // Emit when investor details get modified related to their whitelisting
+    event ChangeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter);
+
+    event ModifyTransferRequirements(
+        TransferType indexed _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    );
+
+    /**
+     * @notice Constructor
+     * @param _securityToken Address of the security token
+     */
+    constructor(address _securityToken, address _polyToken)
+    public
+    Module(_securityToken, _polyToken)
+    {
+
+    }
+
+    /**
+     * @notice Function used to intialize the contract variables
+     * @param _whitelistDataStore Address of the whitelist contract
+     */
+    function configure(address _whitelistDataStore) public onlyFactory {
+        _changeDataStore(_whitelistDataStore);
+    }
+
+    /**
+     * @notice This function returns the signature of configure function
+     */
+    function getInitFunction() public pure returns(bytes4) {
+        return this.configure.selector;
+    }
+
+    /**
+     * @notice Allows ADMIN to change whitelist data store
+     * @param _whitelistDataStore Address of the whitelist contract
+     */
+    function changeDataStore(address _whitelistDataStore) external withPerm(ADMIN) {
+        _changeDataStore(_whitelistDataStore);
+    }
+
+    function _changeDataStore(address _whitelistDataStore) internal {
+        require(_whitelistDataStore != address(0), "Invalid address");
+        emit WhitelistDataStoreChanged(address(whitelistDataStore), _whitelistDataStore);
+        whitelistDataStore = IDataStore(_whitelistDataStore);
+    }
+
+    /**
+     * @notice Used to change the default times used when canSendAfter / canReceiveAfter are zero
+     * @param _defaultCanSendAfter default for zero canSendAfter
+     * @param _defaultCanReceiveAfter default for zero canReceiveAfter
+     */
+    function changeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter) public withPerm(ADMIN) {
+        /* 0 values are also allowed as they represent that the Issuer
+           does not want a default value for these variables.
+           0 is also the default value of these variables */
+        defaults.canSendAfter = _defaultCanSendAfter;
+        defaults.canReceiveAfter = _defaultCanReceiveAfter;
+        emit ChangeDefaults(_defaultCanSendAfter, _defaultCanReceiveAfter);
+    }
+
+    /**
+     * @notice Used to change the Issuance Address
+     * @param _issuanceAddress new address for the issuance
+     */
+    function changeIssuanceAddress(address _issuanceAddress) public withPerm(ADMIN) {
+        // address(0x0) is also a valid value and in most cases, the address that issues tokens is 0x0.
+        issuanceAddress = _issuanceAddress;
+        emit ChangeIssuanceAddress(_issuanceAddress);
+    }
+
+    /**
+     * @notice Default implementation of verifyTransfer used by SecurityToken
+     * If the transfer request comes from the STO, it only checks that the investor is in the whitelist
+     * If the transfer request comes from a token holder, it checks that:
+     * a) Both are on the whitelist
+     * b) Seller's sale lockup period is over
+     * c) Buyer's purchase lockup is over
+     * @param _from Address of the sender
+     * @param _to Address of the receiver
+    */
+    function executeTransfer(
+        address _from,
+        address _to,
+        uint256 /*_amount*/,
+        bytes calldata /*_data*/
+    ) external returns(Result) {
+        (Result success,) = _verifyTransfer(_from, _to);
+        return success;
+    }
+
+    /**
+     * @notice Default implementation of verifyTransfer used by SecurityToken
+     * @param _from Address of the sender
+     * @param _to Address of the receiver
+    */
+    function verifyTransfer(
+        address _from,
+        address _to,
+        uint256 /*_amount*/,
+        bytes memory /* _data */
+    )
+        public
+        view
+        returns(Result, bytes32)
+    {
+        return _verifyTransfer(_from, _to);
+    }
+
+    function _verifyTransfer(
+        address _from,
+        address _to
+    )
+        internal
+        view
+        returns(Result, bytes32)
+    {
+        if (!paused) {
+            TransferRequirements memory txReq;
+            uint64 canSendAfter;
+            uint64 fromExpiry;
+            uint64 toExpiry;
+            uint64 canReceiveAfter;
+
+            if (_from == issuanceAddress) {
+                txReq = transferRequirements[uint8(TransferType.ISSUANCE)];
+            } else if (_to == address(0)) {
+                txReq = transferRequirements[uint8(TransferType.REDEMPTION)];
+            } else {
+                txReq = transferRequirements[uint8(TransferType.GENERAL)];
+            }
+
+            (canSendAfter, fromExpiry, canReceiveAfter, toExpiry) = _getValuesForTransfer(_from, _to);
+
+            if ((txReq.fromValidKYC && !_validExpiry(fromExpiry)) || (txReq.toValidKYC && !_validExpiry(toExpiry))) {
+                return (Result.NA, bytes32(0));
+            }
+
+            (canSendAfter, canReceiveAfter) = _adjustTimes(canSendAfter, canReceiveAfter);
+
+            if ((txReq.fromRestricted && !_validLockTime(canSendAfter)) || (txReq.toRestricted && !_validLockTime(canReceiveAfter))) {
+                return (Result.NA, bytes32(0));
+            }
+
+            return (Result.VALID, getAddressBytes32());
+        }
+        return (Result.NA, bytes32(0));
+    }
+
+    /**
+    * @notice Modifies the successful checks required for a transfer to be deemed valid.
+    * @param _transferType Type of transfer (0 = General, 1 = Issuance, 2 = Redemption)
+    * @param _fromValidKYC Defines if KYC is required for the sender
+    * @param _toValidKYC Defines if KYC is required for the receiver
+    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
+    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
+    */
+    function modifyTransferRequirements(
+        TransferType _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    ) public withPerm(ADMIN) {
+        _modifyTransferRequirements(
+            _transferType,
+            _fromValidKYC,
+            _toValidKYC,
+            _fromRestricted,
+            _toRestricted
+        );
+    }
+
+    /**
+    * @notice Modifies the successful checks required for transfers.
+    * @param _transferTypes Types of transfer (0 = General, 1 = Issuance, 2 = Redemption)
+    * @param _fromValidKYC Defines if KYC is required for the sender
+    * @param _toValidKYC Defines if KYC is required for the receiver
+    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
+    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
+    */
+    function modifyTransferRequirementsMulti(
+        TransferType[] memory _transferTypes,
+        bool[] memory _fromValidKYC,
+        bool[] memory _toValidKYC,
+        bool[] memory _fromRestricted,
+        bool[] memory _toRestricted
+    ) public withPerm(ADMIN) {
+        require(
+            _transferTypes.length == _fromValidKYC.length &&
+            _fromValidKYC.length == _toValidKYC.length &&
+            _toValidKYC.length == _fromRestricted.length &&
+            _fromRestricted.length == _toRestricted.length,
+            "Mismatched input lengths"
+        );
+
+        for (uint256 i = 0; i <  _transferTypes.length; i++) {
+            _modifyTransferRequirements(
+                _transferTypes[i],
+                _fromValidKYC[i],
+                _toValidKYC[i],
+                _fromRestricted[i],
+                _toRestricted[i]
+            );
+        }
+    }
+
+    function _modifyTransferRequirements(
+        TransferType _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    ) internal {
+        transferRequirements[uint8(_transferType)] =
+            TransferRequirements(
+                _fromValidKYC,
+                _toValidKYC,
+                _fromRestricted,
+                _toRestricted
+            );
+
+        emit ModifyTransferRequirements(
+            _transferType,
+            _fromValidKYC,
+            _toValidKYC,
+            _fromRestricted,
+            _toRestricted
+        );
+    }
+
+    /**
+     * @notice Internal function used to check whether the KYC of investor is valid
+     * @param _expiryTime Expiry time of the investor
+     */
+    function _validExpiry(uint64 _expiryTime) internal view returns(bool valid) {
+        if (_expiryTime >= uint64(now)) /*solium-disable-line security/no-block-members*/
+            valid = true;
+    }
+
+    /**
+     * @notice Internal function used to check whether the lock time of investor is valid
+     * @param _lockTime Lock time of the investor
+     */
+    function _validLockTime(uint64 _lockTime) internal view returns(bool valid) {
+        if (_lockTime <= uint64(now)) /*solium-disable-line security/no-block-members*/
+            valid = true;
+    }
+
+    /**
+     * @notice Internal function to adjust times using default values
+     */
+    function _adjustTimes(uint64 _canSendAfter, uint64 _canReceiveAfter) internal view returns(uint64, uint64) {
+        if (_canSendAfter == 0) {
+            _canSendAfter = defaults.canSendAfter;
+        }
+        if (_canReceiveAfter == 0) {
+            _canReceiveAfter = defaults.canReceiveAfter;
+        }
+        return (_canSendAfter, _canReceiveAfter);
+    }
+
+    function _getKey(bytes32 _key1, address _key2) internal pure returns(bytes32) {
+        return bytes32(keccak256(abi.encodePacked(_key1, _key2)));
+    }
+
+    function _getKYCValues(address _investor) internal view returns(
+        uint64 canSendAfter,
+        uint64 canReceiveAfter,
+        uint64 expiryTime,
+        uint8 added
+    )
+    {
+        uint256 data = whitelistDataStore.getUint256(_getKey(WHITELIST, _investor));
+        (canSendAfter, canReceiveAfter, expiryTime, added)  = VersionUtils.unpackKYC(data);
+    }
+
+    function _isExistingInvestor(address _investor) internal view returns(bool) {
+        uint256 data = whitelistDataStore.getUint256(_getKey(WHITELIST, _investor));
+        //extracts `added` from packed `_whitelistData`
+        return uint8(data) == 0 ? false : true;
+    }
+
+    function _getValuesForTransfer(address _from, address _to) internal view returns(uint64 canSendAfter, uint64 fromExpiry, uint64 canReceiveAfter, uint64 toExpiry) {
+        (canSendAfter, , fromExpiry, ) = _getKYCValues(_from);
+        (, canReceiveAfter, toExpiry, ) = _getKYCValues(_to);
+    }
+
+    /**
+     * @dev Returns list of all investors
+     */
+    function getAllInvestors() public view returns(address[] memory investors) {
+        investors = whitelistDataStore.getAddressArray(INVESTORSKEY);
+    }
+
+    /**
+     * @dev Returns list of investors in a range
+     */
+    function getInvestors(uint256 _fromIndex, uint256 _toIndex) public view returns(address[] memory investors) {
+        investors = whitelistDataStore.getAddressArrayElements(INVESTORSKEY, _fromIndex, _toIndex);
+    }
+
+    function getAllInvestorFlags() public view returns(address[] memory investors, uint256[] memory flags) {
+        investors = getAllInvestors();
+        flags = new uint256[](investors.length);
+        for (uint256 i = 0; i < investors.length; i++) {
+            flags[i] = _getInvestorFlags(investors[i]);
+        }
+    }
+
+    function getInvestorFlag(address _investor, uint8 _flag) public view returns(bool value) {
+        uint256 flag = (_getInvestorFlags(_investor) >> _flag) & ONE;
+        value = flag > 0 ? true : false;
+    }
+
+    function getInvestorFlags(address _investor) public view returns(uint256 flags) {
+        flags = _getInvestorFlags(_investor);
+    }
+
+    function _getInvestorFlags(address _investor) public view returns(uint256 flags) {
+        flags = whitelistDataStore.getUint256(_getKey(INVESTORFLAGS, _investor));
+    }
+
+    /**
+     * @dev Returns list of all investors data
+     */
+    function getAllKYCData() external view returns(
+        address[] memory investors,
+        uint256[] memory canSendAfters,
+        uint256[] memory canReceiveAfters,
+        uint256[] memory expiryTimes
+    ) {
+        investors = getAllInvestors();
+        (canSendAfters, canReceiveAfters, expiryTimes) = _kycData(investors);
+        return (investors, canSendAfters, canReceiveAfters, expiryTimes);
+    }
+
+    /**
+     * @dev Returns list of specified investors data
+     */
+    function getKYCData(address[] calldata _investors) external view returns(
+        uint256[] memory,
+        uint256[] memory,
+        uint256[] memory
+    ) {
+        return _kycData(_investors);
+    }
+
+    function _kycData(address[] memory _investors) internal view returns(
+        uint256[] memory,
+        uint256[] memory,
+        uint256[] memory
+    ) {
+        uint256[] memory canSendAfters = new uint256[](_investors.length);
+        uint256[] memory canReceiveAfters = new uint256[](_investors.length);
+        uint256[] memory expiryTimes = new uint256[](_investors.length);
+        for (uint256 i = 0; i < _investors.length; i++) {
+            (canSendAfters[i], canReceiveAfters[i], expiryTimes[i], ) = _getKYCValues(_investors[i]);
+        }
+        return (canSendAfters, canReceiveAfters, expiryTimes);
+    }
+
+    /**
+     * @notice Return the permissions flag that are associated with general trnasfer manager
+     */
+    function getPermissions() public view returns(bytes32[] memory) {
+        bytes32[] memory allPermissions = new bytes32[](1);
+        allPermissions[0] = ADMIN;
+        return allPermissions;
+    }
+
+    /**
+     * @notice return the amount of tokens for a given user as per the partition
+     * @param _partition Identifier
+     * @param _tokenHolder Whom token amount need to query
+     * @param _additionalBalance It is the `_value` that transfer during transfer/transferFrom function call
+     */
+    function getTokensByPartition(bytes32 _partition, address _tokenHolder, uint256 _additionalBalance) external view returns(uint256) {
+        uint256 currentBalance = (msg.sender == securityToken) ? (IERC20(securityToken).balanceOf(_tokenHolder)).add(_additionalBalance) : IERC20(securityToken).balanceOf(_tokenHolder);
+        uint256 canSendAfter;
+        (canSendAfter,,,) = _getKYCValues(_tokenHolder);
+        canSendAfter = (canSendAfter == 0 ? defaults.canSendAfter:  canSendAfter);
+        bool unlockedCheck = paused ? _partition == UNLOCKED : (_partition == UNLOCKED && now >= canSendAfter);
+        if (((_partition == LOCKED && now < canSendAfter) && !paused) || unlockedCheck)
+            return currentBalance;
+        else
+            return 0;
+    }
+
+    function getAddressBytes32() public view returns(bytes32) {
+        return bytes32(uint256(address(this)) << 96);
+    }
+
+}

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManager.sol
@@ -301,12 +301,6 @@ contract SharedWhitelistTransferManager is SharedWhitelistTransferManagerStorage
         (canSendAfter, canReceiveAfter, expiryTime, added)  = VersionUtils.unpackKYC(data);
     }
 
-    function _isExistingInvestor(address _investor) internal view returns(bool) {
-        uint256 data = whitelistDataStore.getUint256(_getKey(WHITELIST, _investor));
-        //extracts `added` from packed `_whitelistData`
-        return uint8(data) == 0 ? false : true;
-    }
-
     function _getValuesForTransfer(address _from, address _to) internal view returns(uint64 canSendAfter, uint64 fromExpiry, uint64 canReceiveAfter, uint64 toExpiry) {
         (canSendAfter, , fromExpiry, ) = _getKYCValues(_from);
         (, canReceiveAfter, toExpiry, ) = _getKYCValues(_to);

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerProxy.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerProxy.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.5.0;
+
+import "../../../../proxy/OwnedUpgradeabilityProxy.sol";
+import "./SharedWhitelistTransferManagerStorage.sol";
+import "../../../../Pausable.sol";
+import "../../../../storage/modules/ModuleStorage.sol";
+
+/**
+ * @title Transfer Manager module that uses a shared whitelist for core transfer validation functionality
+ */
+contract SharedWhitelistTransferManagerProxy is SharedWhitelistTransferManagerStorage, ModuleStorage, Pausable, OwnedUpgradeabilityProxy {
+    /**
+    * @notice Constructor
+    * @param _securityToken Address of the security token
+    * @param _polyAddress Address of the polytoken
+    * @param _implementation representing the address of the new implementation to be set
+    */
+    constructor(
+        string memory _version,
+        address _securityToken,
+        address _polyAddress,
+        address _implementation
+    )
+        public
+        ModuleStorage(_securityToken, _polyAddress)
+    {
+        require(_implementation != address(0), "Implementation address should not be 0x");
+        _upgradeTo(_version, _implementation);
+        transferRequirements[uint8(TransferType.GENERAL)] = TransferRequirements(true, true, true, true);
+        transferRequirements[uint8(TransferType.ISSUANCE)] = TransferRequirements(false, true, false, false);
+        transferRequirements[uint8(TransferType.REDEMPTION)] = TransferRequirements(true, false, false, false);
+    }
+
+}

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerProxy.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerProxy.sol
@@ -4,11 +4,12 @@ import "../../../../proxy/OwnedUpgradeabilityProxy.sol";
 import "./SharedWhitelistTransferManagerStorage.sol";
 import "../../../../Pausable.sol";
 import "../../../../storage/modules/ModuleStorage.sol";
+import "../../../TransferManager/BaseWhitelistTransferManagerStorage.sol";
 
 /**
  * @title Transfer Manager module that uses a shared whitelist for core transfer validation functionality
  */
-contract SharedWhitelistTransferManagerProxy is SharedWhitelistTransferManagerStorage, ModuleStorage, Pausable, OwnedUpgradeabilityProxy {
+contract SharedWhitelistTransferManagerProxy is BaseWhitelistTransferManagerStorage, SharedWhitelistTransferManagerStorage, ModuleStorage, Pausable, OwnedUpgradeabilityProxy {
     /**
     * @notice Constructor
     * @param _securityToken Address of the security token

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerStorage.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerStorage.sol
@@ -7,35 +7,6 @@ import "../../../../interfaces/IDataStore.sol";
  */
 contract SharedWhitelistTransferManagerStorage {
 
-    bytes32 public constant WHITELIST = "WHITELIST";
-    bytes32 public constant INVESTORSKEY = 0xdf3a8dd24acdd05addfc6aeffef7574d2de3f844535ec91e8e0f3e45dba96731; //keccak256(abi.encodePacked("INVESTORS"))
-    bytes32 public constant INVESTORFLAGS = "INVESTORFLAGS";
-    uint256 internal constant ONE = uint256(1);
-
-    enum TransferType { GENERAL, ISSUANCE, REDEMPTION }
-
     //Address where the whitelist data is stored
     IDataStore public whitelistDataStore;
-
-    //Address from which issuances come
-    address public issuanceAddress;
-
-    // Allows all TimeRestrictions to be offset
-    struct Defaults {
-        uint64 canSendAfter;
-        uint64 canReceiveAfter;
-    }
-
-    // Offset to be applied to all timings (except KYC expiry)
-    Defaults public defaults;
-
-    struct TransferRequirements {
-        bool fromValidKYC;
-        bool toValidKYC;
-        bool fromRestricted;
-        bool toRestricted;
-    }
-
-    mapping(uint8 => TransferRequirements) public transferRequirements;
-    // General = 0, Issuance = 1, Redemption = 2
 }

--- a/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerStorage.sol
+++ b/contracts/modules/Experimental/TransferManager/SWTM/SharedWhitelistTransferManagerStorage.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.5.0;
+
+import "../../../../interfaces/IDataStore.sol";
+
+/**
+ * @title Transfer Manager module that uses a shared whitelist for core transfer validation functionality
+ */
+contract SharedWhitelistTransferManagerStorage {
+
+    bytes32 public constant WHITELIST = "WHITELIST";
+    bytes32 public constant INVESTORSKEY = 0xdf3a8dd24acdd05addfc6aeffef7574d2de3f844535ec91e8e0f3e45dba96731; //keccak256(abi.encodePacked("INVESTORS"))
+    bytes32 public constant INVESTORFLAGS = "INVESTORFLAGS";
+    uint256 internal constant ONE = uint256(1);
+
+    enum TransferType { GENERAL, ISSUANCE, REDEMPTION }
+
+    //Address where the whitelist data is stored
+    IDataStore public whitelistDataStore;
+
+    //Address from which issuances come
+    address public issuanceAddress;
+
+    // Allows all TimeRestrictions to be offset
+    struct Defaults {
+        uint64 canSendAfter;
+        uint64 canReceiveAfter;
+    }
+
+    // Offset to be applied to all timings (except KYC expiry)
+    Defaults public defaults;
+
+    struct TransferRequirements {
+        bool fromValidKYC;
+        bool toValidKYC;
+        bool fromRestricted;
+        bool toRestricted;
+    }
+
+    mapping(uint8 => TransferRequirements) public transferRequirements;
+    // General = 0, Issuance = 1, Redemption = 2
+}

--- a/contracts/modules/TransferManager/BaseWhitelistTransferManager.sol
+++ b/contracts/modules/TransferManager/BaseWhitelistTransferManager.sol
@@ -1,0 +1,341 @@
+pragma solidity ^0.5.0;
+
+import "./TransferManager.sol";
+import "./BaseWhitelistTransferManagerStorage.sol";
+import "../../libraries/Encoder.sol";
+import "../../libraries/VersionUtils.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+
+/**
+ * @title Base Transfer Manager contract for core whitelist transfer validation functionality
+ * @dev abstract contract
+ */
+contract BaseWhitelistTransferManager is BaseWhitelistTransferManagerStorage, TransferManager {
+    using SafeMath for uint256;
+    using ECDSA for bytes32;
+
+    // Emit when Issuance address get changed
+    event ChangeIssuanceAddress(address _issuanceAddress);
+
+    // Emit when investor details get modified related to their whitelisting
+    event ChangeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter);
+
+    event ModifyTransferRequirements(
+        TransferType indexed _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    );
+
+    /**
+     * @notice Used to change the default times used when canSendAfter / canReceiveAfter are zero
+     * @param _defaultCanSendAfter default for zero canSendAfter
+     * @param _defaultCanReceiveAfter default for zero canReceiveAfter
+     */
+    function changeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter) public withPerm(ADMIN) {
+        /* 0 values are also allowed as they represent that the Issuer
+           does not want a default value for these variables.
+           0 is also the default value of these variables */
+        defaults.canSendAfter = _defaultCanSendAfter;
+        defaults.canReceiveAfter = _defaultCanReceiveAfter;
+        emit ChangeDefaults(_defaultCanSendAfter, _defaultCanReceiveAfter);
+    }
+
+    /**
+     * @notice Used to change the Issuance Address
+     * @param _issuanceAddress new address for the issuance
+     */
+    function changeIssuanceAddress(address _issuanceAddress) public withPerm(ADMIN) {
+        // address(0x0) is also a valid value and in most cases, the address that issues tokens is 0x0.
+        issuanceAddress = _issuanceAddress;
+        emit ChangeIssuanceAddress(_issuanceAddress);
+    }
+
+    /**
+     * @notice Default implementation of verifyTransfer used by SecurityToken
+     * @dev abstract function to be implemented in derived contract
+     * If the transfer request comes from the STO, it only checks that the investor is in the whitelist
+     * If the transfer request comes from a token holder, it checks that:
+     * a) Both are on the whitelist
+     * b) Seller's sale lockup period is over
+     * c) Buyer's purchase lockup is over
+     * @param _from Address of the sender
+     * @param _to Address of the receiver
+    */
+    function executeTransfer(
+        address _from,
+        address _to,
+        uint256 /*_amount*/,
+        bytes calldata /*_data*/
+    ) external returns(Result);
+
+    /**
+     * @notice Default implementation of verifyTransfer used by SecurityToken
+     * @param _from Address of the sender
+     * @param _to Address of the receiver
+    */
+    function verifyTransfer(
+        address _from,
+        address _to,
+        uint256 /*_amount*/,
+        bytes memory /* _data */
+    )
+        public
+        view
+        returns(Result, bytes32)
+    {
+        return _verifyTransfer(_from, _to);
+    }
+
+    function _verifyTransfer(
+        address _from,
+        address _to
+    )
+        internal
+        view
+        returns(Result, bytes32)
+    {
+        if (!paused) {
+            TransferRequirements memory txReq;
+            uint64 canSendAfter;
+            uint64 fromExpiry;
+            uint64 toExpiry;
+            uint64 canReceiveAfter;
+
+            if (_from == issuanceAddress) {
+                txReq = transferRequirements[uint8(TransferType.ISSUANCE)];
+            } else if (_to == address(0)) {
+                txReq = transferRequirements[uint8(TransferType.REDEMPTION)];
+            } else {
+                txReq = transferRequirements[uint8(TransferType.GENERAL)];
+            }
+
+            (canSendAfter, fromExpiry, canReceiveAfter, toExpiry) = _getValuesForTransfer(_from, _to);
+
+            if ((txReq.fromValidKYC && !_validExpiry(fromExpiry)) || (txReq.toValidKYC && !_validExpiry(toExpiry))) {
+                return (Result.NA, bytes32(0));
+            }
+
+            (canSendAfter, canReceiveAfter) = _adjustTimes(canSendAfter, canReceiveAfter);
+
+            if ((txReq.fromRestricted && !_validLockTime(canSendAfter)) || (txReq.toRestricted && !_validLockTime(canReceiveAfter))) {
+                return (Result.NA, bytes32(0));
+            }
+
+            return (Result.VALID, getAddressBytes32());
+        }
+        return (Result.NA, bytes32(0));
+    }
+
+    /**
+    * @notice Modifies the successful checks required for a transfer to be deemed valid.
+    * @param _transferType Type of transfer (0 = General, 1 = Issuance, 2 = Redemption)
+    * @param _fromValidKYC Defines if KYC is required for the sender
+    * @param _toValidKYC Defines if KYC is required for the receiver
+    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
+    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
+    */
+    function modifyTransferRequirements(
+        TransferType _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    ) public withPerm(ADMIN) {
+        _modifyTransferRequirements(
+            _transferType,
+            _fromValidKYC,
+            _toValidKYC,
+            _fromRestricted,
+            _toRestricted
+        );
+    }
+
+    /**
+    * @notice Modifies the successful checks required for transfers.
+    * @param _transferTypes Types of transfer (0 = General, 1 = Issuance, 2 = Redemption)
+    * @param _fromValidKYC Defines if KYC is required for the sender
+    * @param _toValidKYC Defines if KYC is required for the receiver
+    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
+    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
+    */
+    function modifyTransferRequirementsMulti(
+        TransferType[] memory _transferTypes,
+        bool[] memory _fromValidKYC,
+        bool[] memory _toValidKYC,
+        bool[] memory _fromRestricted,
+        bool[] memory _toRestricted
+    ) public withPerm(ADMIN) {
+        require(
+            _transferTypes.length == _fromValidKYC.length &&
+            _fromValidKYC.length == _toValidKYC.length &&
+            _toValidKYC.length == _fromRestricted.length &&
+            _fromRestricted.length == _toRestricted.length,
+            "Mismatched input lengths"
+        );
+
+        for (uint256 i = 0; i <  _transferTypes.length; i++) {
+            _modifyTransferRequirements(
+                _transferTypes[i],
+                _fromValidKYC[i],
+                _toValidKYC[i],
+                _fromRestricted[i],
+                _toRestricted[i]
+            );
+        }
+    }
+
+    function _modifyTransferRequirements(
+        TransferType _transferType,
+        bool _fromValidKYC,
+        bool _toValidKYC,
+        bool _fromRestricted,
+        bool _toRestricted
+    ) internal {
+        transferRequirements[uint8(_transferType)] =
+            TransferRequirements(
+                _fromValidKYC,
+                _toValidKYC,
+                _fromRestricted,
+                _toRestricted
+            );
+
+        emit ModifyTransferRequirements(
+            _transferType,
+            _fromValidKYC,
+            _toValidKYC,
+            _fromRestricted,
+            _toRestricted
+        );
+    }
+
+    /**
+     * @notice Internal function used to check whether the KYC of investor is valid
+     * @param _expiryTime Expiry time of the investor
+     */
+    function _validExpiry(uint64 _expiryTime) internal view returns(bool valid) {
+        if (_expiryTime >= uint64(now)) /*solium-disable-line security/no-block-members*/
+            valid = true;
+    }
+
+    /**
+     * @notice Internal function used to check whether the lock time of investor is valid
+     * @param _lockTime Lock time of the investor
+     */
+    function _validLockTime(uint64 _lockTime) internal view returns(bool valid) {
+        if (_lockTime <= uint64(now)) /*solium-disable-line security/no-block-members*/
+            valid = true;
+    }
+
+    /**
+     * @notice Internal function to adjust times using default values
+     */
+    function _adjustTimes(uint64 _canSendAfter, uint64 _canReceiveAfter) internal view returns(uint64, uint64) {
+        if (_canSendAfter == 0) {
+            _canSendAfter = defaults.canSendAfter;
+        }
+        if (_canReceiveAfter == 0) {
+            _canReceiveAfter = defaults.canReceiveAfter;
+        }
+        return (_canSendAfter, _canReceiveAfter);
+    }
+
+    function _isExistingInvestor(address _investor, IDataStore dataStore) internal view returns(bool) {
+        uint256 data = dataStore.getUint256(_getKey(WHITELIST, _investor));
+        //extracts `added` from packed `_whitelistData`
+        return uint8(data) == 0 ? false : true;
+    }
+
+    function _getKey(bytes32 _key1, address _key2) internal pure returns(bytes32) {
+        return bytes32(keccak256(abi.encodePacked(_key1, _key2)));
+    }
+
+    /**
+     * @dev abstract function to be implemented in derived contract
+     */
+    function _getValuesForTransfer(address _from, address _to) internal view returns(uint64 canSendAfter, uint64 fromExpiry, uint64 canReceiveAfter, uint64 toExpiry);
+
+    /**
+     * @dev Returns list of all investors
+     * @dev abstract function to be implemented in derived contract
+     */
+    function getAllInvestors() public view returns(address[] memory investors);
+
+    /**
+     * @dev Returns list of investors in a range
+     * @dev abstract function to be implemented in derived contract
+     */
+    function getInvestors(uint256 _fromIndex, uint256 _toIndex) public view returns(address[] memory investors);
+
+    function getAllInvestorFlags() public view returns(address[] memory investors, uint256[] memory flags) {
+        investors = getAllInvestors();
+        flags = new uint256[](investors.length);
+        for (uint256 i = 0; i < investors.length; i++) {
+            flags[i] = _getInvestorFlags(investors[i]);
+        }
+    }
+
+    function getInvestorFlag(address _investor, uint8 _flag) public view returns(bool value) {
+        uint256 flag = (_getInvestorFlags(_investor) >> _flag) & ONE;
+        value = flag > 0 ? true : false;
+    }
+
+    function getInvestorFlags(address _investor) public view returns(uint256 flags) {
+        flags = _getInvestorFlags(_investor);
+    }
+
+    /**
+     * @dev abstract function to be implemented in derived contract
+     */
+    function _getInvestorFlags(address _investor) internal view returns(uint256 flags);
+
+    /**
+     * @dev Returns list of all investors data
+     */
+    function getAllKYCData() external view returns(
+        address[] memory investors,
+        uint256[] memory canSendAfters,
+        uint256[] memory canReceiveAfters,
+        uint256[] memory expiryTimes
+    ) {
+        investors = getAllInvestors();
+        (canSendAfters, canReceiveAfters, expiryTimes) = _kycData(investors);
+        return (investors, canSendAfters, canReceiveAfters, expiryTimes);
+    }
+
+    /**
+     * @dev Returns list of specified investors data
+     */
+    function getKYCData(address[] calldata _investors) external view returns(
+        uint256[] memory,
+        uint256[] memory,
+        uint256[] memory
+    ) {
+        return _kycData(_investors);
+    }
+
+    /**
+     * @dev abstract function to be implemented in derived contract
+     */
+    function _kycData(address[] memory _investors) internal view returns(
+        uint256[] memory /*canSendAfters*/,
+        uint256[] memory /*canReceiveAfters*/,
+        uint256[] memory /*expiryTimes*/
+    );
+
+    /**
+     * @notice Return the permissions flag that are associated with general trnasfer manager
+     */
+    function getPermissions() public view returns(bytes32[] memory) {
+        bytes32[] memory allPermissions = new bytes32[](1);
+        allPermissions[0] = ADMIN;
+        return allPermissions;
+    }
+
+    function getAddressBytes32() public view returns(bytes32) {
+        return bytes32(uint256(address(this)) << 96);
+    }
+
+}

--- a/contracts/modules/TransferManager/BaseWhitelistTransferManagerStorage.sol
+++ b/contracts/modules/TransferManager/BaseWhitelistTransferManagerStorage.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @title Base Whitelist Transfer Manager Storage Contract
+ */
+contract BaseWhitelistTransferManagerStorage {
+
+    bytes32 public constant WHITELIST = "WHITELIST";
+    bytes32 public constant INVESTORSKEY = 0xdf3a8dd24acdd05addfc6aeffef7574d2de3f844535ec91e8e0f3e45dba96731; //keccak256(abi.encodePacked("INVESTORS"))
+    bytes32 public constant INVESTORFLAGS = "INVESTORFLAGS";
+    uint256 internal constant ONE = uint256(1);
+
+    enum TransferType { GENERAL, ISSUANCE, REDEMPTION }
+
+    //Address from which issuances come
+    address public issuanceAddress;
+
+    // Allows all TimeRestrictions to be offset
+    struct Defaults {
+        uint64 canSendAfter;
+        uint64 canReceiveAfter;
+    }
+
+    // Offset to be applied to all timings (except KYC expiry)
+    Defaults public defaults;
+
+    struct TransferRequirements {
+        bool fromValidKYC;
+        bool toValidKYC;
+        bool fromRestricted;
+        bool toRestricted;
+    }
+
+    mapping(uint8 => TransferRequirements) public transferRequirements;
+    // General = 0, Issuance = 1, Redemption = 2
+
+}

--- a/contracts/modules/TransferManager/GTM/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GTM/GeneralTransferManager.sol
@@ -1,30 +1,16 @@
 pragma solidity ^0.5.0;
 
-import "../TransferManager.sol";
-import "../../../libraries/Encoder.sol";
-import "../../../libraries/VersionUtils.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import "openzeppelin-solidity/contracts/cryptography/ECDSA.sol";
+import "../BaseWhitelistTransferManager.sol";
+import "../BaseWhitelistTransferManagerStorage.sol";
 import "./GeneralTransferManagerStorage.sol";
 
 /**
  * @title Transfer Manager module for core transfer validation functionality
  */
-contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManager {
+contract GeneralTransferManager is BaseWhitelistTransferManagerStorage, GeneralTransferManagerStorage, BaseWhitelistTransferManager {
     using SafeMath for uint256;
     using ECDSA for bytes32;
 
-    // Emit when Issuance address get changed
-    event ChangeIssuanceAddress(address _issuanceAddress);
-
-    // Emit when investor details get modified related to their whitelisting
-    event ChangeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter);
-
-    // _canSendAfter is the time from which the _investor can send tokens
-    // _canReceiveAfter is the time from which the _investor can receive tokens
-    // if allowAllWhitelistIssuances is TRUE, then _canReceiveAfter is ignored when receiving tokens from the issuance address
-    // if allowAllWhitelistTransfers is TRUE, then _canReceiveAfter and _canSendAfter is ignored when sending or receiving tokens
-    // in any case, any investor sending or receiving tokens, must have a _expiryTime in the future
     event ModifyKYCData(
         address indexed _investor,
         address indexed _addedBy,
@@ -37,14 +23,6 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
         address indexed _investor,
         uint8 indexed _flag,
         bool _value
-    );
-
-    event ModifyTransferRequirements(
-        TransferType indexed _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
     );
 
     /**
@@ -66,30 +44,7 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
     }
 
     /**
-     * @notice Used to change the default times used when canSendAfter / canReceiveAfter are zero
-     * @param _defaultCanSendAfter default for zero canSendAfter
-     * @param _defaultCanReceiveAfter default for zero canReceiveAfter
-     */
-    function changeDefaults(uint64 _defaultCanSendAfter, uint64 _defaultCanReceiveAfter) public withPerm(ADMIN) {
-        /* 0 values are also allowed as they represent that the Issuer
-           does not want a default value for these variables.
-           0 is also the default value of these variables */
-        defaults.canSendAfter = _defaultCanSendAfter;
-        defaults.canReceiveAfter = _defaultCanReceiveAfter;
-        emit ChangeDefaults(_defaultCanSendAfter, _defaultCanReceiveAfter);
-    }
-
-    /**
-     * @notice Used to change the Issuance Address
-     * @param _issuanceAddress new address for the issuance
-     */
-    function changeIssuanceAddress(address _issuanceAddress) public withPerm(ADMIN) {
-        // address(0x0) is also a valid value and in most cases, the address that issues tokens is 0x0.
-        issuanceAddress = _issuanceAddress;
-        emit ChangeIssuanceAddress(_issuanceAddress);
-    }
-
-    /**
+     * @dev overrides abstract function from base contract
      * @notice Default implementation of verifyTransfer used by SecurityToken
      * If the transfer request comes from the STO, it only checks that the investor is in the whitelist
      * If the transfer request comes from a token holder, it checks that:
@@ -129,147 +84,6 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
             abi.decode(_data, (address[], uint256[], uint256[], uint256[], bytes));
         _modifyKYCDataSignedMulti(investor, canSendAfter, canReceiveAfter, expiryTime, _validFrom, _validTo, _nonce, signature);
     }
-
-    /**
-     * @notice Default implementation of verifyTransfer used by SecurityToken
-     * @param _from Address of the sender
-     * @param _to Address of the receiver
-    */
-    function verifyTransfer(
-        address _from,
-        address _to,
-        uint256 /*_amount*/,
-        bytes memory /* _data */
-    )
-        public
-        view
-        returns(Result, bytes32)
-    {
-        return _verifyTransfer(_from, _to);
-    }
-
-    function _verifyTransfer(
-        address _from,
-        address _to
-    )
-        internal
-        view
-        returns(Result, bytes32)
-    {
-        if (!paused) {
-            TransferRequirements memory txReq;
-            uint64 canSendAfter;
-            uint64 fromExpiry;
-            uint64 toExpiry;
-            uint64 canReceiveAfter;
-
-            if (_from == issuanceAddress) {
-                txReq = transferRequirements[uint8(TransferType.ISSUANCE)];
-            } else if (_to == address(0)) {
-                txReq = transferRequirements[uint8(TransferType.REDEMPTION)];
-            } else {
-                txReq = transferRequirements[uint8(TransferType.GENERAL)];
-            }
-
-            (canSendAfter, fromExpiry, canReceiveAfter, toExpiry) = _getValuesForTransfer(_from, _to);
-
-            if ((txReq.fromValidKYC && !_validExpiry(fromExpiry)) || (txReq.toValidKYC && !_validExpiry(toExpiry))) {
-                return (Result.NA, bytes32(0));
-            }
-
-            (canSendAfter, canReceiveAfter) = _adjustTimes(canSendAfter, canReceiveAfter);
-
-            if ((txReq.fromRestricted && !_validLockTime(canSendAfter)) || (txReq.toRestricted && !_validLockTime(canReceiveAfter))) {
-                return (Result.NA, bytes32(0));
-            }
-
-            return (Result.VALID, getAddressBytes32());
-        }
-        return (Result.NA, bytes32(0));
-    }
-
-    /**
-    * @notice Modifies the successful checks required for a transfer to be deemed valid.
-    * @param _transferType Type of transfer (0 = General, 1 = Issuance, 2 = Redemption)
-    * @param _fromValidKYC Defines if KYC is required for the sender
-    * @param _toValidKYC Defines if KYC is required for the receiver
-    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
-    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
-    */
-    function modifyTransferRequirements(
-        TransferType _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
-    ) public withPerm(ADMIN) {
-        _modifyTransferRequirements(
-            _transferType,
-            _fromValidKYC,
-            _toValidKYC,
-            _fromRestricted,
-            _toRestricted
-        );
-    }
-
-    /**
-    * @notice Modifies the successful checks required for transfers.
-    * @param _transferTypes Types of transfer (0 = General, 1 = Issuance, 2 = Redemption)
-    * @param _fromValidKYC Defines if KYC is required for the sender
-    * @param _toValidKYC Defines if KYC is required for the receiver
-    * @param _fromRestricted Defines if transfer time restriction is checked for the sender
-    * @param _toRestricted Defines if transfer time restriction is checked for the receiver
-    */
-    function modifyTransferRequirementsMulti(
-        TransferType[] memory _transferTypes,
-        bool[] memory _fromValidKYC,
-        bool[] memory _toValidKYC,
-        bool[] memory _fromRestricted,
-        bool[] memory _toRestricted
-    ) public withPerm(ADMIN) {
-        require(
-            _transferTypes.length == _fromValidKYC.length &&
-            _fromValidKYC.length == _toValidKYC.length &&
-            _toValidKYC.length == _fromRestricted.length &&
-            _fromRestricted.length == _toRestricted.length,
-            "Mismatched input lengths"
-        );
-
-        for (uint256 i = 0; i <  _transferTypes.length; i++) {
-            _modifyTransferRequirements(
-                _transferTypes[i],
-                _fromValidKYC[i],
-                _toValidKYC[i],
-                _fromRestricted[i],
-                _toRestricted[i]
-            );
-        }
-    }
-
-    function _modifyTransferRequirements(
-        TransferType _transferType,
-        bool _fromValidKYC,
-        bool _toValidKYC,
-        bool _fromRestricted,
-        bool _toRestricted
-    ) internal {
-        transferRequirements[uint8(_transferType)] =
-            TransferRequirements(
-                _fromValidKYC,
-                _toValidKYC,
-                _fromRestricted,
-                _toRestricted
-            );
-
-        emit ModifyTransferRequirements(
-            _transferType,
-            _fromValidKYC,
-            _toValidKYC,
-            _fromRestricted,
-            _toRestricted
-        );
-    }
-
 
     /**
     * @notice Add or remove KYC info of an investor.
@@ -535,41 +349,6 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
         return true;
     }
 
-    /**
-     * @notice Internal function used to check whether the KYC of investor is valid
-     * @param _expiryTime Expiry time of the investor
-     */
-    function _validExpiry(uint64 _expiryTime) internal view returns(bool valid) {
-        if (_expiryTime >= uint64(now)) /*solium-disable-line security/no-block-members*/
-            valid = true;
-    }
-
-    /**
-     * @notice Internal function used to check whether the lock time of investor is valid
-     * @param _lockTime Lock time of the investor
-     */
-    function _validLockTime(uint64 _lockTime) internal view returns(bool valid) {
-        if (_lockTime <= uint64(now)) /*solium-disable-line security/no-block-members*/
-            valid = true;
-    }
-
-    /**
-     * @notice Internal function to adjust times using default values
-     */
-    function _adjustTimes(uint64 _canSendAfter, uint64 _canReceiveAfter) internal view returns(uint64, uint64) {
-        if (_canSendAfter == 0) {
-            _canSendAfter = defaults.canSendAfter;
-        }
-        if (_canReceiveAfter == 0) {
-            _canReceiveAfter = defaults.canReceiveAfter;
-        }
-        return (_canSendAfter, _canReceiveAfter);
-    }
-
-    function _getKey(bytes32 _key1, address _key2) internal pure returns(bytes32) {
-        return bytes32(keccak256(abi.encodePacked(_key1, _key2)));
-    }
-
     function _getKYCValues(address _investor, IDataStore dataStore) internal view returns(
         uint64 canSendAfter,
         uint64 canReceiveAfter,
@@ -581,12 +360,9 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
         (canSendAfter, canReceiveAfter, expiryTime, added)  = VersionUtils.unpackKYC(data);
     }
 
-    function _isExistingInvestor(address _investor, IDataStore dataStore) internal view returns(bool) {
-        uint256 data = dataStore.getUint256(_getKey(WHITELIST, _investor));
-        //extracts `added` from packed `_whitelistData`
-        return uint8(data) == 0 ? false : true;
-    }
-
+    /**
+     * @dev overrides abstract function from base contract
+     */
     function _getValuesForTransfer(address _from, address _to) internal view returns(uint64 canSendAfter, uint64 fromExpiry, uint64 canReceiveAfter, uint64 toExpiry) {
         IDataStore dataStore = getDataStore();
         (canSendAfter, , fromExpiry, ) = _getKYCValues(_from, dataStore);
@@ -595,6 +371,7 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
 
     /**
      * @dev Returns list of all investors
+     * @dev overrides abstract function from base contract
      */
     function getAllInvestors() public view returns(address[] memory investors) {
         IDataStore dataStore = getDataStore();
@@ -603,59 +380,28 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
 
     /**
      * @dev Returns list of investors in a range
+     * @dev overrides abstract function from base contract
      */
     function getInvestors(uint256 _fromIndex, uint256 _toIndex) public view returns(address[] memory investors) {
         IDataStore dataStore = getDataStore();
         investors = dataStore.getAddressArrayElements(INVESTORSKEY, _fromIndex, _toIndex);
     }
 
-    function getAllInvestorFlags() public view returns(address[] memory investors, uint256[] memory flags) {
-        investors = getAllInvestors();
-        flags = new uint256[](investors.length);
-        for (uint256 i = 0; i < investors.length; i++) {
-            flags[i] = _getInvestorFlags(investors[i]);
-        }
-    }
-
-    function getInvestorFlag(address _investor, uint8 _flag) public view returns(bool value) {
-        uint256 flag = (_getInvestorFlags(_investor) >> _flag) & ONE;
-        value = flag > 0 ? true : false;
-    }
-
     function getInvestorFlags(address _investor) public view returns(uint256 flags) {
         flags = _getInvestorFlags(_investor);
     }
 
-    function _getInvestorFlags(address _investor) public view returns(uint256 flags) {
+    /**
+     * @dev overrides abstract function from base contract
+     */
+    function _getInvestorFlags(address _investor) internal view returns(uint256 flags) {
         IDataStore dataStore = getDataStore();
         flags = dataStore.getUint256(_getKey(INVESTORFLAGS, _investor));
     }
 
     /**
-     * @dev Returns list of all investors data
+     * @dev overrides abstract function from base contract
      */
-    function getAllKYCData() external view returns(
-        address[] memory investors,
-        uint256[] memory canSendAfters,
-        uint256[] memory canReceiveAfters,
-        uint256[] memory expiryTimes
-    ) {
-        investors = getAllInvestors();
-        (canSendAfters, canReceiveAfters, expiryTimes) = _kycData(investors);
-        return (investors, canSendAfters, canReceiveAfters, expiryTimes);
-    }
-
-    /**
-     * @dev Returns list of specified investors data
-     */
-    function getKYCData(address[] calldata _investors) external view returns(
-        uint256[] memory,
-        uint256[] memory,
-        uint256[] memory
-    ) {
-        return _kycData(_investors);
-    }
-
     function _kycData(address[] memory _investors) internal view returns(
         uint256[] memory,
         uint256[] memory,
@@ -668,15 +414,6 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
             (canSendAfters[i], canReceiveAfters[i], expiryTimes[i], ) = _getKYCValues(_investors[i], getDataStore());
         }
         return (canSendAfters, canReceiveAfters, expiryTimes);
-    }
-
-    /**
-     * @notice Return the permissions flag that are associated with general trnasfer manager
-     */
-    function getPermissions() public view returns(bytes32[] memory) {
-        bytes32[] memory allPermissions = new bytes32[](1);
-        allPermissions[0] = ADMIN;
-        return allPermissions;
     }
 
     /**
@@ -695,10 +432,6 @@ contract GeneralTransferManager is GeneralTransferManagerStorage, TransferManage
             return currentBalance;
         else
             return 0;
-    }
-
-    function getAddressBytes32() public view returns(bytes32) {
-        return bytes32(uint256(address(this)) << 96);
     }
 
 }

--- a/contracts/modules/TransferManager/GTM/GeneralTransferManager.sol
+++ b/contracts/modules/TransferManager/GTM/GeneralTransferManager.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.0;
 
 import "../BaseWhitelistTransferManager.sol";
-import "../BaseWhitelistTransferManagerStorage.sol";
 import "./GeneralTransferManagerStorage.sol";
 
 /**

--- a/contracts/modules/TransferManager/GTM/GeneralTransferManagerProxy.sol
+++ b/contracts/modules/TransferManager/GTM/GeneralTransferManagerProxy.sol
@@ -2,13 +2,14 @@ pragma solidity ^0.5.0;
 
 import "../../../proxy/OwnedUpgradeabilityProxy.sol";
 import "./GeneralTransferManagerStorage.sol";
+import "../BaseWhitelistTransferManagerStorage.sol";
 import "../../../Pausable.sol";
 import "../../../storage/modules/ModuleStorage.sol";
 
 /**
  * @title Transfer Manager module for core transfer validation functionality
  */
-contract GeneralTransferManagerProxy is GeneralTransferManagerStorage, ModuleStorage, Pausable, OwnedUpgradeabilityProxy {
+contract GeneralTransferManagerProxy is BaseWhitelistTransferManagerStorage, GeneralTransferManagerStorage, ModuleStorage, Pausable, OwnedUpgradeabilityProxy {
     /**
     * @notice Constructor
     * @param _securityToken Address of the security token

--- a/contracts/modules/TransferManager/GTM/GeneralTransferManagerStorage.sol
+++ b/contracts/modules/TransferManager/GTM/GeneralTransferManagerStorage.sol
@@ -5,35 +5,6 @@ pragma solidity ^0.5.0;
  */
 contract GeneralTransferManagerStorage {
 
-    bytes32 public constant WHITELIST = "WHITELIST";
-    bytes32 public constant INVESTORSKEY = 0xdf3a8dd24acdd05addfc6aeffef7574d2de3f844535ec91e8e0f3e45dba96731; //keccak256(abi.encodePacked("INVESTORS"))
-    bytes32 public constant INVESTORFLAGS = "INVESTORFLAGS";
-    uint256 internal constant ONE = uint256(1);
-
-    enum TransferType { GENERAL, ISSUANCE, REDEMPTION }
-
-    //Address from which issuances come
-    address public issuanceAddress;
-
-    // Allows all TimeRestrictions to be offset
-    struct Defaults {
-        uint64 canSendAfter;
-        uint64 canReceiveAfter;
-    }
-
-    // Offset to be applied to all timings (except KYC expiry)
-    Defaults public defaults;
-
     // Map of used nonces by customer
     mapping(address => mapping(uint256 => bool)) public nonceMap;
-
-    struct TransferRequirements {
-        bool fromValidKYC;
-        bool toValidKYC;
-        bool fromRestricted;
-        bool toRestricted;
-    }
-
-    mapping(uint8 => TransferRequirements) public transferRequirements;
-    // General = 0, Issuance = 1, Redemption = 2
 }

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -55,6 +55,8 @@ const PLCRVotingCheckpointFactory = artifacts.require("./PLCRVotingCheckpointFac
 const WeightedVoteCheckpointFactory = artifacts.require("./WeightedVoteCheckpointFactory.sol");
 const PLCRVotingCheckpoint = artifacts.require("./PLCRVotingCheckpoint.sol");
 const WeightedVoteCheckpoint = artifacts.require("./WeightedVoteCheckpoint.sol");
+const SharedWhitelistTransferManager = artifacts.require("./SharedWhitelistTransferManager.sol");
+const SharedWhitelistTransferManagerFactory = artifacts.require("./SharedWhitelistTransferManagerFactory.sol");
 
 const Web3 = require("web3");
 let BN = Web3.utils.BN;
@@ -118,6 +120,9 @@ let I_StablePOLYOracle;
 let I_PLCRVotingCheckpointFactory;
 let I_WeightedVoteCheckpointLogic;
 let I_PLCRVotingCheckpointLogic;
+let I_SharedWhitelistTransferManagerLogic;
+let I_SharedWhitelistTransferManagerFactory;
+let I_SharedWhitelistTransferManager;
 
 // Initial fee for ticker registry and security token registry
 const initRegFee = new BN(web3.utils.toWei("250"));
@@ -643,4 +648,29 @@ export async function deployWeightedVoteCheckpoint(accountPolymath, MRProxyInsta
 
     await registerAndVerifyByMR(I_WeightedVoteCheckpointFactory.address, accountPolymath, MRProxyInstance);
     return new Array(I_WeightedVoteCheckpointFactory);
+}
+
+export async function deploySWTMAndVerify(accountPolymath, MRProxyInstance, setupCost, feeInPoly = true) {
+    I_SharedWhitelistTransferManagerLogic = await SharedWhitelistTransferManager.new(
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
+        { from: accountPolymath }
+    );
+    I_SharedWhitelistTransferManagerFactory = await SharedWhitelistTransferManagerFactory.new(
+        setupCost,
+        new BN(0),
+        I_SharedWhitelistTransferManagerLogic.address,
+        I_PolymathRegistry.address,
+        feeInPoly,
+        { from: accountPolymath }
+    );
+
+    assert.notEqual(
+        I_SharedWhitelistTransferManagerFactory.address.valueOf(),
+        "0x0000000000000000000000000000000000000000",
+        "SharedWhitelistTransferManagerFactory contract was not deployed"
+    );
+
+    await registerAndVerifyByMR(I_SharedWhitelistTransferManagerFactory.address, accountPolymath, MRProxyInstance);
+    return new Array(I_SharedWhitelistTransferManagerFactory);
 }

--- a/test/ze_shared_whitelist_transfer_manager.js
+++ b/test/ze_shared_whitelist_transfer_manager.js
@@ -1,0 +1,818 @@
+import latestTime from "./helpers/latestTime";
+import { duration, promisifyLogWatch, latestBlock } from "./helpers/utils";
+import { takeSnapshot, increaseTime, revertToSnapshot } from "./helpers/time";
+import { encodeProxyCall, encodeModuleCall } from "./helpers/encodeCall";
+import { catchRevert } from "./helpers/exceptions";
+import { setUpPolymathNetwork, deployGPMAndVerifyed, deployDummySTOAndVerifyed, deployGTMAndVerifyed, deploySWTMAndVerify } from "./helpers/createInstances";
+
+const DummySTO = artifacts.require("./DummySTO.sol");
+const SecurityToken = artifacts.require("./SecurityToken.sol");
+const GeneralTransferManager = artifacts.require("./GeneralTransferManager");
+const GeneralPermissionManager = artifacts.require("./GeneralPermissionManager");
+const STGetter = artifacts.require("./STGetter.sol");
+const SharedWhitelistTransferManager = artifacts.require("./SharedWhitelistTransferManager");
+
+
+const Web3 = require("web3");
+let BN = Web3.utils.BN;
+const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545")); // Hardcoded development port
+
+contract("SharedWhitelistTransferManager", async (accounts) => {
+    // Accounts Variable declaration
+    let POLYMATH;
+    let ISSUER1;
+    let ISSUER2;
+    let INVESTOR1;
+    let INVESTOR2;
+    let INVESTOR3;
+    let INVESTOR4;
+    let DELEGATE;
+    let AFFILIATE1;
+    let AFFILIATE2;
+
+    // investor Details
+    let fromTime;
+    let toTime;
+    let expiryTime;
+
+    let message = "Transaction Should Fail!";
+
+    // Contract Instance Declaration
+    let I_GeneralPermissionManagerFactory;
+    let I_GeneralTransferManagerFactory;
+    let I_SecurityTokenRegistryProxy;
+    let I_GeneralPermissionManager = [];
+    let I_GeneralTransferManager = [];
+    let I_ModuleRegistryProxy;
+    let I_ModuleRegistry;
+    let I_FeatureRegistry;
+    let I_SecurityTokenRegistry;
+    let I_DummySTOFactory;
+    let P_DummySTOFactory;
+    let I_STFactory;
+    let I_SecurityToken = [];
+    let I_STRProxied;
+    let I_MRProxied;
+    let I_DummySTO;
+    let I_PolyToken;
+    let I_PolymathRegistry;
+    let P_GeneralTransferManagerFactory;
+    let I_STRGetter;
+    let I_STGetter;
+    let I_SharedWhitelistTransferManagerFactory;
+    let P_SharedWhitelistTransferManagerFactory;
+    let I_SharedWhitelistTransferManager;
+    let stGetter = [];
+
+    let NAME = [];
+    let SYMBOL = [];
+    let TOKENDETAILS = [];
+
+    // SecurityToken 1 Details
+    NAME[0] = "Team";
+    SYMBOL[0] = "SAP";
+    TOKENDETAILS[0] = "This is equity type of issuance";
+
+    // SecurityToken 2 Details
+    NAME[1] = "FOB Token";
+    SYMBOL[1] = "FOB";
+    TOKENDETAILS[1] = "This is equity type of issuance";
+
+    // Module key
+    const delegateManagerKey = 1;
+    const transferManagerKey = 2;
+    const stoKey = 3;
+
+    // Initial fee for ticker registry and security token registry
+    const REGFEE = new BN(web3.utils.toWei("1000"));
+    const STOSetupCost = 0;
+
+    // Dummy STO details
+    let startTime;
+    let endTime;
+    const cap = new BN(web3.utils.toWei("10", "ether"));
+    const someString = "A string which is not used";
+    const STOParameters = ["uint256", "uint256", "uint256", "string"];
+
+    let currentTime;
+    const address_zero = "0x0000000000000000000000000000000000000000";
+    const one_address = "0x0000000000000000000000000000000000000001";
+    let SIGNER;
+    let snapid;
+
+    const functionSignature = {
+        name: "configure",
+        type: "function",
+        inputs: [
+            {
+                type: "address",
+                name: "_whitelistDataStore"
+            }
+        ]
+    };
+
+    before(async () => {
+        currentTime = new BN(await latestTime());
+        fromTime = await latestTime();
+        toTime = await latestTime();
+        expiryTime = toTime + duration.days(15);
+        startTime = await latestTime() + duration.seconds(5000); // Start time will be 5000 seconds more than the latest time
+        endTime = startTime + duration.days(80); // Add 80 days more
+
+        POLYMATH = accounts[0];
+        ISSUER1 = accounts[1];
+        ISSUER2 = accounts[2];
+
+        INVESTOR1 = accounts[8];
+        INVESTOR2 = accounts[9];
+        DELEGATE = accounts[7];
+        INVESTOR3 = accounts[5];
+        INVESTOR4 = accounts[6];
+
+        AFFILIATE1 = accounts[3];
+        AFFILIATE2 = accounts[4];
+
+        let oneeth = new BN(web3.utils.toWei("1", "ether"));
+        SIGNER = web3.eth.accounts.create();
+        await web3.eth.personal.importRawKey(SIGNER.privateKey, "");
+        await web3.eth.personal.unlockAccount(SIGNER.address, "", 6000);
+        await web3.eth.sendTransaction({ from: ISSUER1, to: SIGNER.address, value: oneeth });
+
+        // Step 1: Deploy the genral PM ecosystem
+        let instances = await setUpPolymathNetwork(POLYMATH, ISSUER1);
+
+        [
+            I_PolymathRegistry,
+            I_PolyToken,
+            I_FeatureRegistry,
+            I_ModuleRegistry,
+            I_ModuleRegistryProxy,
+            I_MRProxied,
+            I_GeneralTransferManagerFactory,
+            I_STFactory,
+            I_SecurityTokenRegistry,
+            I_SecurityTokenRegistryProxy,
+            I_STRProxied,
+            I_STRGetter,
+            I_STGetter
+        ] = instances;
+
+        [I_GeneralPermissionManagerFactory] = await deployGPMAndVerifyed(POLYMATH, I_MRProxied, STOSetupCost);
+        [P_GeneralTransferManagerFactory] = await deployGTMAndVerifyed(POLYMATH, I_MRProxied, new BN(web3.utils.toWei("500")));
+        [I_DummySTOFactory] = await deployDummySTOAndVerifyed(POLYMATH, I_MRProxied, STOSetupCost);
+        [P_DummySTOFactory] = await deployDummySTOAndVerifyed(POLYMATH, I_MRProxied, new BN(web3.utils.toWei("500")));
+        [I_SharedWhitelistTransferManagerFactory] = await deploySWTMAndVerify(POLYMATH, I_MRProxied, STOSetupCost);
+        [P_SharedWhitelistTransferManagerFactory] = await deploySWTMAndVerify(POLYMATH, I_MRProxied, new BN(web3.utils.toWei("500")));
+
+        // Printing all the contract addresses
+        console.log(`
+        --------------------- Polymath Network Smart Contracts: ---------------------
+        PolymathRegistry:                       ${I_PolymathRegistry.address}
+        SecurityTokenRegistryProxy:             ${I_SecurityTokenRegistryProxy.address}
+        SecurityTokenRegistry:                  ${I_SecurityTokenRegistry.address}
+        ModuleRegistryProxy:                    ${I_ModuleRegistryProxy.address}
+        ModuleRegistry:                         ${I_ModuleRegistry.address}
+        FeatureRegistry:                        ${I_FeatureRegistry.address}
+
+        STFactory:                              ${I_STFactory.address}
+        GeneralTransferManagerFactory:          ${I_GeneralTransferManagerFactory.address}
+        GeneralPermissionManagerFactory:        ${I_GeneralPermissionManagerFactory.address}
+        SharedWhitelistTransferManagerFactory:  ${I_SharedWhitelistTransferManagerFactory.address}
+
+        DummySTOFactory:                        ${I_DummySTOFactory.address}
+        -----------------------------------------------------------------------------
+        `);
+    });
+
+    describe("Generate the Security Tokens", async () => {
+        it("Should register the first ticker before the generation of the first security token", async () => {
+            await I_PolyToken.getTokens(REGFEE, ISSUER1);
+            await I_PolyToken.approve(I_STRProxied.address, REGFEE, { from: ISSUER1 });
+            let tx = await I_STRProxied.registerTicker(ISSUER1, SYMBOL[0], NAME[0], { from: ISSUER1 });
+            assert.equal(tx.logs[0].args._owner, ISSUER1);
+            assert.equal(tx.logs[0].args._ticker, SYMBOL[0]);
+        });
+
+        it("Should generate the first new security token with the same symbol as registered above", async () => {
+            await I_PolyToken.getTokens(REGFEE, ISSUER1);
+            await I_PolyToken.approve(I_STRProxied.address, REGFEE, { from: ISSUER1 });
+
+            let tx = await I_STRProxied.generateNewSecurityToken(NAME[0], SYMBOL[0], TOKENDETAILS[0], true, ISSUER1, 0, { from: ISSUER1 });
+            assert.equal(tx.logs[1].args._ticker, SYMBOL[0], "SecurityToken doesn't get deployed");
+
+            I_SecurityToken[0] = await SecurityToken.at(tx.logs[1].args._securityTokenAddress);
+            stGetter[0] = await STGetter.at(I_SecurityToken[0].address);
+            assert.equal(await stGetter[0].getTreasuryWallet.call(), ISSUER1, "Incorrect wallet set")
+            const log = (await I_SecurityToken[0].getPastEvents('ModuleAdded', {filter: {transactionHash: tx.transactionHash}}))[0];
+
+            // Verify that GeneralTransferManager module get added successfully or not
+            assert.equal(log.args._types[0].toString(), transferManagerKey);
+            assert.equal(web3.utils.hexToString(log.args._name), "GeneralTransferManager");
+        });
+
+        it("Should initialize the auto attached modules", async () => {
+            let moduleData = (await stGetter[0].getModulesByType(transferManagerKey))[0];
+            I_GeneralTransferManager[0] = await GeneralTransferManager.at(moduleData);
+        });
+
+        it("Should register the second ticker before the generation of the second security token", async () => {
+            await I_PolyToken.getTokens(REGFEE, ISSUER2);
+            await I_PolyToken.approve(I_STRProxied.address, REGFEE, { from: ISSUER2 });
+            let tx = await I_STRProxied.registerTicker(ISSUER2, SYMBOL[1], NAME[1], { from: ISSUER2 });
+            assert.equal(tx.logs[0].args._owner, ISSUER2);
+            assert.equal(tx.logs[0].args._ticker, SYMBOL[1]);
+        });
+
+        it("Should generate the second new security token with the same symbol as registered above", async () => {
+            await I_PolyToken.getTokens(REGFEE, ISSUER2);
+            await I_PolyToken.approve(I_STRProxied.address, REGFEE, { from: ISSUER2 });
+
+            let tx = await I_STRProxied.generateNewSecurityToken(NAME[1], SYMBOL[1], TOKENDETAILS[1], true, ISSUER2, 0, { from: ISSUER2 });
+            assert.equal(tx.logs[1].args._ticker, SYMBOL[1], "SecurityToken doesn't get deployed");
+
+            I_SecurityToken[1] = await SecurityToken.at(tx.logs[1].args._securityTokenAddress);
+            stGetter[1] = await STGetter.at(I_SecurityToken[1].address);
+            assert.equal(await stGetter[1].getTreasuryWallet.call(), ISSUER2, "Incorrect wallet set")
+            const log = (await I_SecurityToken[1].getPastEvents('ModuleAdded', {filter: {transactionHash: tx.transactionHash}}))[0];
+
+            // Verify that GeneralTransferManager module get added successfully or not
+            assert.equal(log.args._types[0].toString(), transferManagerKey);
+            assert.equal(web3.utils.hexToString(log.args._name), "GeneralTransferManager");
+        });
+
+        it("Should initialize the auto attached modules", async () => {
+            let moduleData = (await stGetter[1].getModulesByType(transferManagerKey))[0];
+            I_GeneralTransferManager[1] = await GeneralTransferManager.at(moduleData);
+        });
+
+        it("Should attach the paid SWTM to the second token -- failed because of no tokens", async () => {
+            // Use dataStore from the first token
+            let dataStore = await I_SecurityToken[0].dataStore.call();
+            let bytes = web3.eth.abi.encodeFunctionCall(functionSignature, [dataStore]);
+
+            await catchRevert(
+                I_SecurityToken[1].addModule(P_SharedWhitelistTransferManagerFactory.address, bytes, new BN(web3.utils.toWei("500")), new BN(0), false,
+                { from: ISSUER2 })
+            );
+        });
+
+        it("Should attach the paid SWTM to the second token", async () => {
+            let snap_id = await takeSnapshot();
+            // Use dataStore from the first token
+            let dataStore = await I_SecurityToken[0].dataStore.call();
+            let bytes = web3.eth.abi.encodeFunctionCall(functionSignature, [dataStore]);
+
+            await I_PolyToken.getTokens(new BN(web3.utils.toWei("500")), I_SecurityToken[1].address);
+            await I_SecurityToken[1].addModule(P_SharedWhitelistTransferManagerFactory.address, bytes, new BN(web3.utils.toWei("500")), new BN(0), false, {
+                from: ISSUER2
+            });
+            await revertToSnapshot(snap_id);
+        });
+
+        it("Should whitelist the affiliates through the first token before the STO attached", async () => {
+            console.log(`Estimate gas of one Whitelist:
+                ${await I_GeneralTransferManager[0].modifyKYCData.estimateGas(
+                    AFFILIATE1,
+                    currentTime + currentTime.add(new BN(duration.days(30))),
+                    currentTime + currentTime.add(new BN(duration.days(90))),
+                    currentTime + currentTime.add(new BN(duration.days(965))),
+                    {
+                        from: ISSUER1
+                    }
+                )}`
+            );
+            let fromTime1 = currentTime + currentTime.add(new BN(duration.days(30)));
+            let fromTime2 = currentTime.add(new BN(duration.days(30)));
+            let toTime1 =  currentTime + currentTime.add(new BN(duration.days(90)));
+            let toTime2 = currentTime.add(new BN(duration.days(90)));
+            let expiryTime1 = currentTime + currentTime.add(new BN(duration.days(965)));
+            let expiryTime2 = currentTime.add(new BN(duration.days(365)));
+
+            let tx = await I_GeneralTransferManager[0].modifyKYCDataMulti(
+                [AFFILIATE1, AFFILIATE2],
+                [fromTime1, fromTime2],
+                [toTime1, toTime2],
+                [expiryTime1, expiryTime2],
+                {
+                    from: ISSUER1,
+                    gas: 6000000
+                }
+            );
+            // Set canNotBuyFromSto flags for Affiliates
+            await I_GeneralTransferManager[0].modifyInvestorFlagMulti([AFFILIATE1, AFFILIATE2], [1, 1], [true, true], { from: ISSUER1 });
+            assert.equal(tx.logs[0].args._investor, AFFILIATE1);
+            assert.equal(tx.logs[1].args._investor, AFFILIATE2);
+            assert.deepEqual(await I_GeneralTransferManager[0].getAllInvestors.call(), [AFFILIATE1, AFFILIATE2]);
+            console.log(await I_GeneralTransferManager[0].getAllKYCData.call());
+            let data = await I_GeneralTransferManager[0].getKYCData.call([AFFILIATE1, AFFILIATE2]);
+            assert.equal(data[0][0].toString(), fromTime1);
+            assert.equal(data[0][1].toString(), fromTime2);
+            assert.equal(data[1][0].toString(), toTime1);
+            assert.equal(data[1][1].toString(), toTime2);
+            assert.equal(data[2][0].toString(), expiryTime1);
+            assert.equal(data[2][1].toString(), expiryTime2);
+            assert.equal(await I_GeneralTransferManager[0].getInvestorFlag(AFFILIATE1, 1), true);
+            assert.equal(await I_GeneralTransferManager[0].getInvestorFlag(AFFILIATE2, 1), true);
+        });
+
+        it("Should mint the second token to the affiliates - failed Investors not whitelisted for second token", async () => {
+            await catchRevert(
+                I_SecurityToken[1].issueMulti([AFFILIATE1, AFFILIATE2], [new BN(100).mul(new BN(10).pow(new BN(18))), new BN(10).pow(new BN(20))], {
+                from: ISSUER2,
+                gas: 6000000
+            }));
+        });
+
+        it("Should attach the SWTM to the second token", async () => {
+            // Use dataStore from the first token
+            let dataStore = await I_SecurityToken[0].dataStore.call();
+            let bytes = web3.eth.abi.encodeFunctionCall(functionSignature, [dataStore]);
+
+            await I_SecurityToken[1].addModule(I_SharedWhitelistTransferManagerFactory.address, bytes, new BN(web3.utils.toWei("2000")), new BN(0), false, {
+                from: ISSUER2
+            });
+            let moduleData = (await stGetter[1].getModulesByType(transferManagerKey))[1];
+            I_SharedWhitelistTransferManager = await SharedWhitelistTransferManager.at(moduleData);
+
+        });
+
+        it("Should mint the second token to the affiliates", async () => {
+            console.log(`
+                Estimate gas cost for minting the tokens: ${await I_SecurityToken[1].issueMulti.estimateGas([AFFILIATE1, AFFILIATE2], [new BN(100).mul(new BN(10).pow(new BN(18))), new BN(10).pow(new BN(20))], {
+                    from: ISSUER2
+                })}
+            `)
+
+            await I_SecurityToken[1].issueMulti([AFFILIATE1, AFFILIATE2], [new BN(100).mul(new BN(10).pow(new BN(18))), new BN(10).pow(new BN(20))], {
+                from: ISSUER2,
+                gas: 6000000
+            });
+            assert.equal((await I_SecurityToken[1].balanceOf.call(AFFILIATE1)).div(new BN(10).pow(new BN(18))).toNumber(), 100);
+            assert.equal((await I_SecurityToken[1].balanceOf.call(AFFILIATE2)).div(new BN(10).pow(new BN(18))).toNumber(), 100);
+        });
+
+        it("Should successfully attach the STO factory to the second security token", async () => {
+            let bytesSTO = encodeModuleCall(STOParameters, [
+                await latestTime() + duration.seconds(1000),
+                await latestTime() + duration.days(40),
+                cap,
+                someString
+            ]);
+            const tx = await I_SecurityToken[1].addModule(I_DummySTOFactory.address, bytesSTO, new BN(0), new BN(0), false, { from: ISSUER2 });
+            assert.equal(tx.logs[2].args._types[0].toNumber(), stoKey, "DummySTO doesn't get deployed");
+            assert.equal(
+                web3.utils.toAscii(tx.logs[2].args._name).replace(/\u0000/g, ""),
+                "DummySTO",
+                "DummySTOFactory module was not added"
+            );
+            I_DummySTO = await DummySTO.at(tx.logs[2].args._module);
+        });
+
+        it("Should successfully attach the permission manager factory to the first security token", async () => {
+            const tx = await I_SecurityToken[0].addModule(I_GeneralPermissionManagerFactory.address, "0x0", new BN(0), new BN(0), false, { from: ISSUER1 });
+            assert.equal(tx.logs[2].args._types[0].toNumber(), delegateManagerKey, "GeneralPermissionManager doesn't get deployed");
+            assert.equal(
+                web3.utils.toAscii(tx.logs[2].args._name).replace(/\u0000/g, ""),
+                "GeneralPermissionManager",
+                "GeneralPermissionManager module was not added"
+            );
+            I_GeneralPermissionManager[0] = await GeneralPermissionManager.at(tx.logs[2].args._module);
+        });
+
+        it("Should successfully attach the permission manager factory to the second security token", async () => {
+            const tx = await I_SecurityToken[1].addModule(I_GeneralPermissionManagerFactory.address, "0x0", new BN(0), new BN(0), false, { from: ISSUER2 });
+            assert.equal(tx.logs[2].args._types[0].toNumber(), delegateManagerKey, "GeneralPermissionManager doesn't get deployed");
+            assert.equal(
+                web3.utils.toAscii(tx.logs[2].args._name).replace(/\u0000/g, ""),
+                "GeneralPermissionManager",
+                "GeneralPermissionManager module was not added"
+            );
+            I_GeneralPermissionManager[1] = await GeneralPermissionManager.at(tx.logs[2].args._module);
+        });
+
+        it("should have transfer requirements initialized", async () => {
+            let transferRestrions = await I_GeneralTransferManager[0].transferRequirements(0);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], true);
+            assert.equal(transferRestrions[3], true);
+            transferRestrions = await I_GeneralTransferManager[0].transferRequirements(1);
+            assert.equal(transferRestrions[0], false);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+            transferRestrions = await I_GeneralTransferManager[0].transferRequirements(2);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], false);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+
+            transferRestrions = await I_GeneralTransferManager[1].transferRequirements(0);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], true);
+            assert.equal(transferRestrions[3], true);
+            transferRestrions = await I_GeneralTransferManager[1].transferRequirements(1);
+            assert.equal(transferRestrions[0], false);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+            transferRestrions = await I_GeneralTransferManager[1].transferRequirements(2);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], false);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+
+            transferRestrions = await I_SharedWhitelistTransferManager.transferRequirements(0);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], true);
+            assert.equal(transferRestrions[3], true);
+            transferRestrions = await I_SharedWhitelistTransferManager.transferRequirements(1);
+            assert.equal(transferRestrions[0], false);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+            transferRestrions = await I_SharedWhitelistTransferManager.transferRequirements(2);
+            assert.equal(transferRestrions[0], true);
+            assert.equal(transferRestrions[1], false);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+        });
+
+        it("should not allow unauthorized people to change transfer requirements", async () => {
+            await catchRevert(
+                I_SharedWhitelistTransferManager.modifyTransferRequirementsMulti(
+                    [0, 1, 2],
+                    [true, false, true],
+                    [true, true, false],
+                    [false, false, false],
+                    [false, false, false],
+                    { from: INVESTOR1 }
+                )
+            );
+            await catchRevert(I_SharedWhitelistTransferManager.modifyTransferRequirements(0, false, false, false, false, { from: INVESTOR1 }));
+        });
+    });
+
+    describe("Buy tokens using on-chain whitelist", async () => {
+        it("Should buy the tokens -- Failed due to investor is not in the whitelist", async () => {
+            await catchRevert(I_DummySTO.generateTokens(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 }));
+        });
+
+        it("Should Buy the second tokens from the STO", async () => {
+            // Add the Investor in to the first token whitelist
+
+            let tx = await I_GeneralTransferManager[0].modifyKYCData(
+                INVESTOR1,
+                currentTime,
+                currentTime,
+                currentTime.add(new BN(duration.days(10))),
+                {
+                    from: ISSUER1,
+                    gas: 6000000
+                }
+            );
+
+            assert.equal(
+                tx.logs[0].args._investor.toLowerCase(),
+                INVESTOR1.toLowerCase(),
+                "Failed in adding the investor in whitelist"
+            );
+
+            // Jump time
+            await increaseTime(5000);
+
+            // Mint some tokens
+            console.log(
+                `Gas usage of minting of tokens: ${await I_DummySTO.generateTokens.estimateGas(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 })}`
+            )
+            await I_DummySTO.generateTokens(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 });
+
+            assert.equal((await I_SecurityToken[1].balanceOf(INVESTOR1)).toString(), new BN(web3.utils.toWei("1", "ether")).toString());
+        });
+
+        it("Should Buy second tokens for AFFILIATE1 from the STO", async () => {
+            await I_DummySTO.generateTokens(AFFILIATE1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 });
+        });
+
+        it("Should Set canNotBuyFromSto flag for the affiliates through the second token GTM", async () => {
+            // Set canNotBuyFromSto flags for Affiliates
+            await I_GeneralTransferManager[1].modifyInvestorFlagMulti([AFFILIATE1, AFFILIATE2], [1, 1], [true, true], { from: ISSUER2 });
+            assert.equal(await I_GeneralTransferManager[1].getInvestorFlag(AFFILIATE1, 1), true);
+            assert.equal(await I_GeneralTransferManager[1].getInvestorFlag(AFFILIATE2, 1), true);
+        });
+
+        it("Should fail in buying the second token from the STO for AFFILIATE1", async () => {
+            await catchRevert(I_DummySTO.generateTokens(AFFILIATE1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 }));
+        });
+
+        it("Should fail in buying the tokens from the STO -- because amount is 0", async () => {
+            await catchRevert(I_DummySTO.generateTokens(INVESTOR1, new BN(0), { from: ISSUER2 }));
+        });
+
+        it("Should fail in buying the tokens from the STO -- because STO is paused", async () => {
+            await I_DummySTO.pause({ from: ISSUER2 });
+            await catchRevert(I_DummySTO.generateTokens(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 }));
+            // Reverting the changes releated to pause
+            await I_DummySTO.unpause({ from: ISSUER2 });
+        });
+
+        it("Should buy more tokens from the STO to INVESTOR1", async () => {
+            await I_DummySTO.generateTokens(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 });
+            assert.equal((await I_SecurityToken[1].balanceOf(INVESTOR1)).toString(), new BN(web3.utils.toWei("2", "ether")).toString());
+        });
+
+        it("Should fail in investing the money in STO -- expiry limit reached", async () => {
+            await increaseTime(duration.days(10));
+
+            await catchRevert(I_DummySTO.generateTokens(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: ISSUER2 }));
+        });
+    });
+
+    describe("Transfer tokens using on-chain shared whitelist from the first token", async () => {
+
+        it("Should transfer the second tokens from INVESTOR1 to INVESTOR2", async () => {
+            // Add the Investor in to the whitelist
+            // snap_id = await takeSnapshot();
+            let tx = await I_GeneralTransferManager[0].modifyKYCData(INVESTOR1, new BN(0), new BN(0), currentTime.add(new BN(duration.days(20))), {
+                from: ISSUER1,
+                gas: 6000000
+            });
+
+            assert.equal(
+                tx.logs[0].args._investor.toLowerCase(),
+                INVESTOR1.toLowerCase(),
+                "Failed in adding the investor in whitelist"
+            );
+
+            tx = await I_GeneralTransferManager[0].modifyKYCData(
+                INVESTOR2,
+                currentTime,
+                currentTime,
+                currentTime.add(new BN(duration.days(20))),
+                {
+                    from: ISSUER1,
+                    gas: 6000000
+                }
+            );
+
+            assert.equal(
+                tx.logs[0].args._investor.toLowerCase(),
+                INVESTOR2.toLowerCase(),
+                "Failed in adding the investor in whitelist"
+            );
+
+            // Jump time
+            await increaseTime(5000);
+
+            // Can transfer tokens
+            await I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 });
+            assert.equal((await I_SecurityToken[1].balanceOf(INVESTOR1)).toString(), new BN(web3.utils.toWei("1", "ether")).toString());
+            assert.equal((await I_SecurityToken[1].balanceOf(INVESTOR2)).toString(), new BN(web3.utils.toWei("1", "ether")).toString());
+        });
+
+        it("Add a from default and check transfers are disabled -- failed to disable, defaults from first token GTM are not applied to second token SWTM", async () => {
+            let snap_id = await takeSnapshot();
+
+            let tx = await I_GeneralTransferManager[0].changeDefaults(currentTime.add(new BN(duration.days(12))), new BN(0), { from: ISSUER1 });
+            await I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR2 });
+            await I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 });
+
+            await revertToSnapshot(snap_id);
+        });
+
+        it("Add a from default to SWTM and check transfers are disabled then enabled in the future", async () => {
+            let tx = await I_SharedWhitelistTransferManager.changeDefaults(currentTime.add(new BN(duration.days(12))), new BN(0), { from: ISSUER2 });
+            await I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR2 });
+            await catchRevert(I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 }));
+            await increaseTime(duration.days(5));
+            await I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 });
+        });
+
+        it("Add a to default and check transfers are disabled -- failed to disable, defaults from first token GTM are not applied to second token SWTM", async () => {
+            let snap_id = await takeSnapshot();
+
+            let tx = await I_GeneralTransferManager[0].changeDefaults(0, currentTime.add(new BN(duration.days(16))), { from: ISSUER1 });
+            await I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR2 });
+            await I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 });
+
+            await revertToSnapshot(snap_id);
+        });
+
+        it("Add a to default to SWTM and check transfers are disabled then enabled in the future", async () => {
+            let tx = await I_SharedWhitelistTransferManager.changeDefaults(0, currentTime.add(new BN(duration.days(16))), { from: ISSUER2 });
+            await catchRevert(I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR2 }));
+            await I_SecurityToken[1].transfer(INVESTOR2, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR1 });
+            await increaseTime(duration.days(2));
+            await I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("1", "ether")), { from: INVESTOR2 });
+            // Revert changes
+            await I_GeneralTransferManager[0].modifyKYCData(INVESTOR2, new BN(0), new BN(0), new BN(0), {
+                from: ISSUER1,
+                gas: 6000000
+            });
+            await I_GeneralTransferManager[0].changeDefaults(0, new BN(0), { from: ISSUER1 });
+            await I_SharedWhitelistTransferManager.changeDefaults(0, new BN(0), { from: ISSUER2 });
+        });
+
+    });
+
+    describe("Test miscellaneous functions", async () => {
+
+        it("Should change with Share Whitelist -- failed address zero", async () => {
+            await catchRevert(I_SharedWhitelistTransferManager.changeDataStore(address_zero, { from: ISSUER2}));
+        });
+
+        it("Should change with Share Whitelist -- failed invalid permission", async () => {
+            await catchRevert(I_SharedWhitelistTransferManager.changeDataStore(INVESTOR1, { from: INVESTOR1}));
+        });
+
+        it("Should change with Share Whitelist", async () => {
+            let snap_id = await takeSnapshot();
+
+            await I_SharedWhitelistTransferManager.changeDataStore(INVESTOR1, { from: ISSUER2});
+            let whitelist = await I_SharedWhitelistTransferManager.whitelistDataStore.call();
+            assert.equal(whitelist, INVESTOR1, "New whitelist address not set")
+
+            await revertToSnapshot(snap_id);
+        });
+
+        it("Should get the permission", async () => {
+            let perm = await I_SharedWhitelistTransferManager.getPermissions.call();
+            assert.equal(web3.utils.toAscii(perm[0]).replace(/\u0000/g, ""), "ADMIN");
+        });
+
+        it("Should set a usage fee for the SWTM", async () => {
+            // Fail due to wrong owner
+            await catchRevert(I_SharedWhitelistTransferManagerFactory.changeUsageCost(new BN(web3.utils.toWei("1", "ether")), { from: ISSUER1}));
+            await I_SharedWhitelistTransferManagerFactory.changeUsageCost(new BN(web3.utils.toWei("1", "ether")), { from: POLYMATH });
+        });
+
+        it("Should fail to pull fees as no budget set", async () => {
+            await catchRevert(I_SharedWhitelistTransferManager.takeUsageFee( { from: POLYMATH }));
+        });
+
+        it("Should set a budget for the SharedWhitelistTransferManager", async () => {
+            await I_SecurityToken[1].changeModuleBudget(I_SharedWhitelistTransferManager.address, new BN(10).pow(new BN(19)), true, { from: ISSUER2 });
+            await catchRevert(I_SharedWhitelistTransferManager.takeUsageFee({ from: ISSUER2 }));
+            await I_PolyToken.getTokens(new BN(10).pow(new BN(19)), ISSUER2);
+            await I_PolyToken.transfer(I_SecurityToken[1].address, new BN(10).pow(new BN(19)), { from: ISSUER2 });
+        });
+
+        it("Factory owner should pull fees - fails as not permissioned by issuer", async () => {
+            await catchRevert(I_SharedWhitelistTransferManager.takeUsageFee({ from: DELEGATE }));
+        });
+
+        it("Module owner should pull fees", async () => {
+            let log = await I_GeneralPermissionManager[1].addDelegate(DELEGATE, web3.utils.fromAscii("My details"), { from: ISSUER2 });
+            assert.equal(log.logs[0].args._delegate, DELEGATE);
+
+            await I_GeneralPermissionManager[1].changePermission(DELEGATE, I_SharedWhitelistTransferManager.address, web3.utils.fromAscii("ADMIN"), true, {
+                from: ISSUER2
+            });
+            let balanceBefore = await I_PolyToken.balanceOf(POLYMATH);
+            await I_SharedWhitelistTransferManager.takeUsageFee({ from: DELEGATE });
+            let balanceAfter = await I_PolyToken.balanceOf(POLYMATH);
+
+            assert.equal(balanceBefore.add(new BN(web3.utils.toWei("1", "ether"))).toString(), balanceAfter.toString(), "Fee is transferred");
+        });
+
+        it("Should allow authorized people to modify transfer requirements", async () => {
+            await I_SharedWhitelistTransferManager.modifyTransferRequirements(0, false, true, false, false, { from: ISSUER2 });
+            let transferRestrions = await I_SharedWhitelistTransferManager.transferRequirements(0);
+            assert.equal(transferRestrions[0], false);
+            assert.equal(transferRestrions[1], true);
+            assert.equal(transferRestrions[2], false);
+            assert.equal(transferRestrions[3], false);
+        });
+
+        it("Should pause and fail in trasfering the tokens", async () => {
+            await I_SharedWhitelistTransferManager.modifyTransferRequirementsMulti(
+                [0, 1, 2],
+                [true, false, true],
+                [true, true, false],
+                [false, false, false],
+                [false, false, false],
+                { from: ISSUER2 }
+            );
+            await I_SharedWhitelistTransferManager.pause({ from: ISSUER2 });
+            await catchRevert(I_SecurityToken[1].transfer(INVESTOR1, new BN(web3.utils.toWei("2", "ether")), { from: INVESTOR2 }));
+        });
+
+        it("Should change the Issuance address", async () => {
+            let tx = await I_SharedWhitelistTransferManager.changeIssuanceAddress(INVESTOR2, { from: DELEGATE });
+            assert.equal(tx.logs[0].args._issuanceAddress, INVESTOR2);
+        });
+
+        it("Should unpause the transfers", async () => {
+            await I_SharedWhitelistTransferManager.unpause({ from: ISSUER2 });
+
+            assert.isFalse(await I_SharedWhitelistTransferManager.paused.call());
+        });
+    });
+
+    describe("Test cases for the getTokensByPartition", async() => {
+
+        it("Should check the partition balance before changing the canSendAfter & canReceiveAfter", async() => {
+            assert.equal(web3.utils.fromWei((await I_SecurityToken[1].balanceOf.call(INVESTOR2)).toString()), 1);
+            assert.equal(web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("LOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                0
+            );
+            assert.equal(
+                web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("UNLOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                1
+            );
+        });
+
+        it("Should change the canSendAfter and canRecieveAfter of the investor2", async() => {
+            let canSendAfter = await latestTime() + duration.days(10);
+            let canRecieveAfter = await latestTime() + duration.days(10);
+            let expiryTime = await latestTime() + duration.days(100);
+
+            let tx = await I_GeneralTransferManager[0].modifyKYCData(
+                INVESTOR2,
+                canSendAfter,
+                canRecieveAfter,
+                expiryTime,
+                {
+                    from: ISSUER1,
+                    gas: 6000000
+                }
+            );
+            assert.equal(tx.logs[0].args._investor, INVESTOR2);
+            assert.equal(
+                web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("LOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                1
+            );
+
+            assert.equal(
+                web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("UNLOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                0
+            );
+        });
+
+        it("Should check the values of partition balance after the SWTM pause", async() => {
+            await I_SharedWhitelistTransferManager.pause({from: ISSUER2});
+            assert.equal(
+                web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("LOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                0
+            );
+
+            assert.equal(
+                web3.utils.fromWei(
+                (
+                    await I_SharedWhitelistTransferManager.getTokensByPartition.call(web3.utils.toHex("UNLOCKED"), INVESTOR2, new BN(0))
+                ).toString()
+                ),
+                1
+            );
+            await I_SharedWhitelistTransferManager.unpause({from: ISSUER2});
+        })
+    });
+
+    describe("Shared Whitelist Transfer Manager Factory test cases", async () => {
+
+        it("Should get the exact details of the factory", async () => {
+            assert.equal(await I_SharedWhitelistTransferManagerFactory.setupCost.call(), 0);
+            assert.equal((await I_SharedWhitelistTransferManagerFactory.types.call())[0], 2);
+            assert.equal(
+                web3.utils.toAscii(await I_SharedWhitelistTransferManagerFactory.name.call()).replace(/\u0000/g, ""),
+                "SharedWhitelistTransferManager",
+                "Wrong Module added"
+            );
+            assert.equal(
+                await I_SharedWhitelistTransferManagerFactory.description.call(),
+                "Manage transfers using a shared time based whitelist",
+                "Wrong Module added"
+            );
+            assert.equal(await I_SharedWhitelistTransferManagerFactory.title.call(), "Share Whitelist Transfer Manager", "Wrong Module added");
+            assert.equal(await I_SharedWhitelistTransferManagerFactory.version.call(), "3.0.0");
+        });
+
+        it("Should get the tags of the factory", async () => {
+            let tags = await I_SharedWhitelistTransferManagerFactory.tags.call();
+            assert.equal(web3.utils.toAscii(tags[0]).replace(/\u0000/g, ""), "Shared Whitelist");
+        });
+    });
+
+});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our Submission guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
New Transfer Manager that allows an issuer to attach an external whitelist dataStore.
This allows an issuer with more than one token to share a whitelist between multiple tokens or to use a whtelist maintained by an external provider.

(Note: Due to current methods used to call flags e.g. isAccredited and Can not buy from STO these need to be managed on the token specific DataStore and not the shared whitelist.) 

### What is the current behavior? 
Token specific whtelisting only


### What is the new behavior?
Support external and internal whitelists at the same time


### Does this PR introduce a breaking change?
No


### Any Other information: