### PR TITLE
Relax provider check

### DIFF
--- a/CLI/commands/common/global.js
+++ b/CLI/commands/common/global.js
@@ -25,7 +25,7 @@ function getGasPrice(networkId) {
 }
 
 function providerValidator(url) {
-  var expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+  var expression = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}(\.[a-z]{2,4})*\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
   var regex = new RegExp(expression);
   return url.match(regex);
 }


### PR DESCRIPTION
This change allows the remote node to connect to remote addresses of
form http://machinename:8545/.  This change is necessary to allow a
docker image to connect to a docker image that provides ethereum
services.


### Please check if the PR fulfills these requirements
- [ X] The commit message follows our Submission guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 
(Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? 
(You can also link to an open issue here)

The provider check rejects connection to remote addresses of form http://machinename:8545/

### What is the new behavior?
(Define and describe any new functionality. Clarify if this is a feature change)

Remote addresses of form http://machinename:8545/ are now accepted

### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)

No
### Any Other information:
