### PR TITLE
Added constructors

### DIFF
--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -195,6 +195,11 @@ contract SecurityTokenRegistry is EternalStorage, Proxy {
     // Initialization
     /////////////////////////////
 
+    // Constructor
+    constructor() public {
+        set(INITIALIZE, true);
+    }
+
     /**
      * @notice Initializes instance of STR
      * @param _polymathRegistry is the address of the Polymath Registry

--- a/contracts/SecurityTokenRegistry.sol
+++ b/contracts/SecurityTokenRegistry.sol
@@ -162,6 +162,11 @@ contract SecurityTokenRegistry is EternalStorage, Proxy {
         _;
     }
 
+    modifier onlyOwnerOrSelf() {
+        require(msg.sender == owner() || msg.sender == address(this), "Only owner or self");
+        _;
+    }
+
     /**
      * @notice Modifier to make a function callable only when the contract is not paused.
      */
@@ -293,7 +298,7 @@ contract SecurityTokenRegistry is EternalStorage, Proxy {
      * @notice Set the getter contract address
      * @param _getterContract Address of the contract
      */
-    function setGetterRegistry(address _getterContract) public onlyOwner {
+    function setGetterRegistry(address _getterContract) public onlyOwnerOrSelf {
         require(_getterContract != address(0));
         set(STRGETTER, _getterContract);
     }

--- a/contracts/mocks/MockSTRGetter.sol
+++ b/contracts/mocks/MockSTRGetter.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+import "../STRGetter.sol";
+
+/**
+ * @title Registry contract for issuers to register their security tokens
+ */
+contract MockSTRGetter is STRGetter {
+    /// @notice It is a dummy function
+    /// Alert! Alert! Do NOT use it for the mainnet release
+
+    function newFunction() public pure returns (uint256) {
+        return 99;
+    }
+
+}

--- a/contracts/mocks/SecurityTokenRegistryMock.sol
+++ b/contracts/mocks/SecurityTokenRegistryMock.sol
@@ -8,8 +8,20 @@ import "../SecurityTokenRegistry.sol";
 contract SecurityTokenRegistryMock is SecurityTokenRegistry {
     /// @notice It is a dummy function
     /// Alert! Alert! Do NOT use it for the mainnet release
+
+    modifier onlyOwnerOrSelf() {
+        require(msg.sender == owner() || msg.sender == address(this), "Only owner or self");
+        _;
+    }
+
+    uint256 public someValue;
+    
     function changeTheDeployedAddress(string memory _ticker, address _newSecurityTokenAddress) public {
         set(Encoder.getKey("tickerToSecurityToken", _ticker), _newSecurityTokenAddress);
+    }
+
+    function configure(uint256 _someValue) public onlyOwnerOrSelf {
+        someValue = _someValue;
     }
 
 }

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -72,6 +72,11 @@ contract SecurityToken is ERC20, ReentrancyGuard, SecurityTokenStorage, IERC1594
     // Emit when the budget allocated to a module is changed
     event ModuleBudgetChanged(uint8[] _moduleTypes, address _module, uint256 _oldBudget, uint256 _budget); //Event emitted by the tokenLib.
 
+    // Constructor
+    constructor() public {
+        initialized = true;
+    }
+
     /**
      * @notice Initialization function
      * @dev Expected to be called atomically with the proxy being created, by the owner of the token

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -305,7 +305,7 @@ module.exports = function(deployer, network, accounts) {
         })
         .then(() => {
             // B) Deploy the SecurityTokenLogic Contract
-            return deployer.deploy(SecurityTokenLogic, "", "", 0, { from: PolymathAccount });
+            return deployer.deploy(SecurityTokenLogic, { from: PolymathAccount });
         })
         .then(() => {
             // B) Deploy the DataStoreFactory Contract

--- a/test/helpers/createInstances.js
+++ b/test/helpers/createInstances.js
@@ -248,7 +248,7 @@ async function deployGTM(account_polymath) {
 
 async function deploySTFactory(account_polymath) {
     I_STGetter = await STGetter.new({from: account_polymath});
-    I_SecurityToken = await SecurityTokenLogic.new("", "", 0, {from: account_polymath});
+    I_SecurityToken = await SecurityTokenLogic.new({ from: account_polymath });
     console.log("STL - " + I_SecurityToken.address);
     let I_DataStoreLogic = await DataStoreLogic.new({ from: account_polymath });
     let I_DataStoreFactory = await DataStoreFactory.new(I_DataStoreLogic.address, { from: account_polymath });

--- a/test/helpers/encodeCall.js
+++ b/test/helpers/encodeCall.js
@@ -11,3 +11,9 @@ export function encodeModuleCall(parametersType, values) {
     const params = abi.rawEncode(parametersType, values).toString("hex");
     return "0x" + methodId + params;
 }
+
+export function encodeCall(methodName, parametersType, values) {
+    const methodId = abi.methodID(methodName, parametersType).toString("hex");
+    const params = abi.rawEncode(parametersType, values).toString("hex");
+    return "0x" + methodId + params;
+}

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -731,14 +731,24 @@ contract("SecurityTokenRegistry", async (accounts) => {
         it("Should fail to upgrade the logic contract of the STRProxy -- bad owner", async () => {
             await I_STRProxied.pause({ from: account_polymath });
 
+            const STRProxyConfigParameters = ["uint256"];
+            let bytesProxy = encodeModuleCall(STRProxyConfigParameters, [
+                99
+            ]);
+
             await catchRevert(
-                I_SecurityTokenRegistryProxy.upgradeTo("1.1.0", I_SecurityTokenRegistryV2.address, { from: account_temp }),
+                I_SecurityTokenRegistryProxy.upgradeToAndCall("1.1.0", I_SecurityTokenRegistryV2.address, bytesProxy, { from: account_temp }),
                 "tx revert -> bad owner"
             );
         });
 
         it("Should upgrade the logic contract into the STRProxy", async () => {
-            await I_SecurityTokenRegistryProxy.upgradeTo("1.1.0", I_SecurityTokenRegistryV2.address, { from: account_polymath });
+            const STRProxyConfigParameters = ["uint256"];
+            let bytesProxy = encodeModuleCall(STRProxyConfigParameters, [
+                99
+            ]);
+
+            await I_SecurityTokenRegistryProxy.upgradeToAndCall("1.1.0", I_SecurityTokenRegistryV2.address, bytesProxy, { from: account_polymath });
             I_STRProxied = await SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
             assert.isTrue(await I_STRProxied.getBoolValue.call(web3.utils.soliditySha3("paused")), "Paused value should be false");
         });

--- a/test/t_security_token_registry_proxy.js
+++ b/test/t_security_token_registry_proxy.js
@@ -1,11 +1,13 @@
 import { duration, promisifyLogWatch, latestBlock } from "./helpers/utils";
-import { encodeProxyCall } from "./helpers/encodeCall";
+import { encodeProxyCall, encodeCall } from "./helpers/encodeCall";
+import { takeSnapshot, increaseTime, revertToSnapshot } from "./helpers/time";
 import { catchRevert } from "./helpers/exceptions";
 import { setUpPolymathNetwork } from "./helpers/createInstances";
 
 const SecurityTokenRegistry = artifacts.require("./SecurityTokenRegistry.sol");
 const SecurityTokenRegistryProxy = artifacts.require("./SecurityTokenRegistryProxy.sol");
 const SecurityTokenRegistryMock = artifacts.require("./SecurityTokenRegistryMock.sol");
+const MockSTRGetter = artifacts.require("./MockSTRGetter.sol");
 const OwnedUpgradeabilityProxy = artifacts.require("./OwnedUpgradeabilityProxy.sol");
 const STFactory = artifacts.require("./STFactory.sol");
 const SecurityToken = artifacts.require("./SecurityToken.sol");
@@ -149,6 +151,41 @@ contract("SecurityTokenRegistryProxy", async (accounts) => {
                 web3.utils.toWei("250")
             );
         });
+
+        it("Upgrade the proxy again and change getter", async () => {
+          let snapId = await takeSnapshot();
+          const I_MockSTRGetter = await MockSTRGetter.new({from: account_polymath});
+          const I_MockSecurityTokenRegistry = await SecurityTokenRegistry.new({ from: account_polymath });
+          const bytesProxy = encodeCall("setGetterRegistry", ["address"], [I_MockSTRGetter.address]);
+          console.log("Getter: " + I_MockSTRGetter.address);
+          console.log("Registry: " + I_MockSecurityTokenRegistry.address);
+          console.log("STRProxy: " + I_SecurityTokenRegistryProxy.address);
+
+          await I_SecurityTokenRegistryProxy.upgradeToAndCall("2.0.0", I_MockSecurityTokenRegistry.address, bytesProxy, {
+              from: account_polymath
+          });
+
+          let c = await OwnedUpgradeabilityProxy.at(I_SecurityTokenRegistryProxy.address);
+          assert.equal(await readStorage(c.address, 12), I_MockSecurityTokenRegistry.address.toLowerCase());
+          assert.equal(
+              web3.utils
+                  .toAscii(await readStorage(c.address, 11))
+                  .replace(/\u0000/g, "")
+                  .replace(/\n/, ""),
+              "2.0.0"
+          );
+
+          const I_MockSecurityTokenRegistryProxy = await SecurityTokenRegistry.at(I_SecurityTokenRegistryProxy.address);
+          const I_MockSTRGetterProxy = await MockSTRGetter.at(I_SecurityTokenRegistryProxy.address);
+          await I_MockSecurityTokenRegistryProxy.setProtocolFactory(I_STFactory.address, 3, 1, 0);
+          await I_MockSecurityTokenRegistryProxy.setLatestVersion(3, 1, 0);
+          let newValue = await I_MockSTRGetterProxy.newFunction.call();
+          assert.equal(newValue.toNumber(), 99);
+          //assert.isTrue(false);
+          await revertToSnapshot(snapId);
+        });
+
+
     });
 
     describe("Feed some data in storage", async () => {

--- a/test/u_module_registry_proxy.js
+++ b/test/u_module_registry_proxy.js
@@ -140,9 +140,6 @@ contract("ModuleRegistryProxy", async (accounts) => {
             );
 
             let I_SecurityTokenLogic = await SecurityToken.new(
-                "",
-                "",
-                0,
                 { from: account_polymath }
             );
 


### PR DESCRIPTION
The constructors prevent an exploit in case we forget to initialize the implementation contracts.
Ideally, we should always remember to initialize implementation contracts as well.

Fixes audit Issue 1

ps. The same exploit was possible in STR If we forgot to initialize STR implementation. I have fixed that as well in this PR.
