### PR TITLE
Set solcjs as default compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ extract/
 extract.py
 extract.zip
 /test-results
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ jobs:
   include:
     - stage: Test
       install:
-        - echo -ne '\n' | sudo add-apt-repository ppa:ethereum/ethereum
-        - sudo apt-get update
-        - sudo apt-get install -y dpkg
-        - sudo apt-get install -y solc
-        - curl -L -o solc https://github.com/ethereum/solidity/releases/download/v0.5.8/solc-static-linux
-        - sudo mv solc /usr/bin/solc
-        - sudo chmod +x /usr/bin/solc
         - yarn install
       before_script:
         - truffle version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ jobs:
         - yarn install
       before_script:
         - truffle version
-        - solc --version
       script: npm run test
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "homepage": "https://github.com/PolymathNetwork/polymath-core#readme",
   "dependencies": {
+    "dotenv": "^8.0.0",
     "truffle": "^5.0.4",
     "truffle-hdwallet-provider": "^1.0.4",
     "web3-provider-engine": "^14.1.0"

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,9 +1,17 @@
 require('babel-register');
 require('babel-polyfill');
+require('dotenv').config();
 const fs = require('fs');
 const NonceTrackerSubprovider = require("web3-provider-engine/subproviders/nonce-tracker")
 
 const HDWalletProvider = require("truffle-hdwallet-provider");
+
+let ver;
+if (process.env.POLYMATH_NATIVE_SOLC) {
+  ver = "native";
+} else {
+  ver = "0.5.8";
+}
 
 module.exports = {
   networks: {
@@ -59,11 +67,11 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "native",  
+      version: ver,
       settings: {
         optimizer: {
-          enabled: true, 
-          runs: 200    
+          enabled: true,
+          runs: 200
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,6 +1825,11 @@ dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"


### PR DESCRIPTION
If you want to use native solc, set the environment variable POLYMATH_NATIVE_SOLC as true.
You can use dotenv as well. Follow the following steps
1) `yarn` //install dotenv
2) `echo "POLYMATH_NATIVE_SOLC=true" > .env` // creates the required .env file

Also, if you are using native solc, make sure you have solc 0.5.8 installed.
On Linux systems, you can do
```
sudo add-apt-repository ppa:ethereum/ethereum
sudo apt update
sudo apt install -y solc
sudo apt-mark hold solc
curl -L -o solc https://github.com/ethereum/solidity/releases/download/v0.5.8/solc-static-linux
sudo mv solc /usr/bin/solc
sudo chmod +x /usr/bin/solc
```