### PR TITLE
Fixed CTM verifyTransfer bug

### DIFF
--- a/contracts/modules/TransferManager/CTM/CountTransferManager.sol
+++ b/contracts/modules/TransferManager/CTM/CountTransferManager.sol
@@ -39,6 +39,10 @@ contract CountTransferManager is CountTransferManagerStorage, TransferManager {
 
     /**
      * @notice Used to verify the transfer transaction and prevent a transfer if it passes the allowed amount of token holders
+     * @dev module.verifyTransfer is called by SecToken.canTransfer and does not receive the updated holderCount therefore
+     *      verifyTransfer has to manually account for pot. tokenholder changes (by mimicking TokenLib.adjustInvestorCount).
+     *      module.executeTransfer is called by SecToken.transfer|issue|others and receives an updated holderCount 
+     *      as sectoken calls TokenLib.adjustInvestorCount before executeTransfer.
      * @param _from Address of the sender
      * @param _to Address of the receiver
      * @param _amount Amount to send

--- a/test/d_count_transfer_manager.js
+++ b/test/d_count_transfer_manager.js
@@ -311,6 +311,9 @@ contract("CountTransferManager", async (accounts) => {
             );
 
             await catchRevert(I_SecurityToken.issue(account_investor3, new BN(web3.utils.toWei("3", "ether")), "0x0", { from: token_owner }));
+            await catchRevert(I_SecurityToken.transfer(account_investor3, new BN(web3.utils.toWei("1", "ether")), { from: account_investor2 }));
+            let canTransfer = await I_SecurityToken.canTransfer(account_investor3, new BN(web3.utils.toWei("1", "ether")), "0x0", { from: account_investor2 });
+            assert.equal(canTransfer[0], "0x50"); //Transfer failure.
         });
 
         it("Should still be able to add to original token holders", async () => {


### PR DESCRIPTION
Fixed a bug found by Victor

>I found something that seems to be a bug.
I have added a CTM with `maxHolders = 2`
My token has 2 holders:
A -> 800 tokens
B -> 200 tokens
If I call to `canTransfer` on ST20 to check if A can transfer 100 tokens to C, it returns `TransferSuccess`.
Same if I call to `verifyTransfer` on my CTM. It doesn’t return `INVALID`.
But if I actually try to do `transfer` it is reverted.