### PR TITLE
(3.0) Core: ST unit tests:: explicit revert reason checks

### DIFF
--- a/contracts/modules/TransferManager/CTM/CountTransferManager.sol
+++ b/contracts/modules/TransferManager/CTM/CountTransferManager.sol
@@ -33,12 +33,16 @@ contract CountTransferManager is CountTransferManagerStorage, TransferManager {
         external
         returns(Result)
     {
-        (Result success, ) = _verifyTransfer(_from, _to, _amount);
+        (Result success, ) = _verifyTransfer(_from, _to, _amount, securityToken.holderCount());
         return success;
     }
 
     /**
      * @notice Used to verify the transfer transaction and prevent a transfer if it passes the allowed amount of token holders
+     * @dev module.verifyTransfer is called by SecToken.canTransfer and does not receive the updated holderCount therefore
+     *      verifyTransfer has to manually account for pot. tokenholder changes (by mimicking TokenLib.adjustInvestorCount).
+     *      module.executeTransfer is called by SecToken.transfer|issue|others and receives an updated holderCount 
+     *      as sectoken calls TokenLib.adjustInvestorCount before executeTransfer.
      * @param _from Address of the sender
      * @param _to Address of the receiver
      * @param _amount Amount to send
@@ -53,20 +57,33 @@ contract CountTransferManager is CountTransferManagerStorage, TransferManager {
         view
         returns(Result, bytes32)
     {
-        return _verifyTransfer(_from, _to, _amount);
+        uint256 holderCount = securityToken.holderCount();
+        if (_amount != 0 && _from != _to) {
+            // Check whether receiver is a new token holder
+            if (_to != address(0) && securityToken.balanceOf(_to) == 0) {
+                holderCount++;
+            }
+            // Check whether sender is moving all of their tokens
+            if (_amount == securityToken.balanceOf(_from)) {
+                holderCount--;
+            }
+        }
+
+        return _verifyTransfer(_from, _to, _amount, holderCount);
     }
 
     function _verifyTransfer(
         address _from,
         address _to,
-        uint256 _amount
+        uint256 _amount,
+        uint256 _holderCount
     )
         internal
         view
         returns(Result, bytes32)
     {
         if (!paused) {
-            if (maxHolderCount < securityToken.holderCount()) {
+            if (maxHolderCount < _holderCount) {
                 // Allow transfers to existing maxHolders
                 if (securityToken.balanceOf(_to) != 0 || securityToken.balanceOf(_from) == _amount) {
                     return (Result.NA, bytes32(0));

--- a/contracts/tokens/SecurityToken.sol
+++ b/contracts/tokens/SecurityToken.sol
@@ -931,7 +931,7 @@ contract SecurityToken is ERC20, ReentrancyGuard, SecurityTokenStorage, IERC1594
      */
     function canTransferFrom(address _from, address _to, uint256 _value, bytes calldata _data) external view returns (byte reasonCode, bytes32 appCode) {
         (reasonCode, appCode) = _canTransfer(_from, _to, _value, _data);
-        if (isSuccess(reasonCode) && _value > allowance(_from, msg.sender)) {
+        if (_isSuccess(reasonCode) && _value > allowance(_from, msg.sender)) {
             return (StatusCodes.code(StatusCodes.Status.InsufficientAllowance), bytes32(0));
         }
     }
@@ -971,7 +971,7 @@ contract SecurityToken is ERC20, ReentrancyGuard, SecurityTokenStorage, IERC1594
     {
         if (_partition == UNLOCKED) {
             (reasonCode, appStatusCode) = _canTransfer(_from, _to, _value, _data);
-            if (isSuccess(reasonCode)) {
+            if (_isSuccess(reasonCode)) {
                 uint256 beforeBalance = _balanceOfByPartition(LOCKED, _to, 0);
                 uint256 afterbalance = _balanceOfByPartition(LOCKED, _to, _value);
                 toPartition = _returnPartition(beforeBalance, afterbalance, _value);
@@ -1103,7 +1103,7 @@ contract SecurityToken is ERC20, ReentrancyGuard, SecurityTokenStorage, IERC1594
     * @param status Binary ERC-1066 status code
     * @return successful A boolean representing if the status code represents success
     */
-    function isSuccess(byte status) public pure returns (bool successful) {
+    function _isSuccess(byte status) internal pure returns (bool successful) {
         return (status & 0x0F) == 0x01;
     }
 }

--- a/contracts/tokens/SecurityTokenStorage.sol
+++ b/contracts/tokens/SecurityTokenStorage.sol
@@ -8,18 +8,18 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 contract SecurityTokenStorage {
 
-    uint8 constant PERMISSION_KEY = 1;
-    uint8 constant TRANSFER_KEY = 2;
-    uint8 constant MINT_KEY = 3;
-    uint8 constant CHECKPOINT_KEY = 4;
-    uint8 constant BURN_KEY = 5;
-    uint8 constant DATA_KEY = 6;
-    uint8 constant WALLET_KEY = 7;
+    uint8 internal constant PERMISSION_KEY = 1;
+    uint8 internal constant TRANSFER_KEY = 2;
+    uint8 internal constant MINT_KEY = 3;
+    uint8 internal constant CHECKPOINT_KEY = 4;
+    uint8 internal constant BURN_KEY = 5;
+    uint8 internal constant DATA_KEY = 6;
+    uint8 internal constant WALLET_KEY = 7;
 
     bytes32 internal constant INVESTORSKEY = 0xdf3a8dd24acdd05addfc6aeffef7574d2de3f844535ec91e8e0f3e45dba96731; //keccak256(abi.encodePacked("INVESTORS"))
     bytes32 internal constant TREASURY = 0xaae8817359f3dcb67d050f44f3e49f982e0359d90ca4b5f18569926304aaece6; //keccak256(abi.encodePacked("TREASURY_WALLET"))
-    bytes32 public constant LOCKED = "LOCKED";
-    bytes32 public constant UNLOCKED = "UNLOCKED";
+    bytes32 internal constant LOCKED = "LOCKED";
+    bytes32 internal constant UNLOCKED = "UNLOCKED";
 
     //////////////////////////
     /// Document datastructure
@@ -57,7 +57,7 @@ contract SecurityTokenStorage {
     }
 
     //Naming scheme to match Ownable
-    address public _owner;
+    address internal _owner;
     address public tokenFactory;
     bool public initialized;
 

--- a/test/d_count_transfer_manager.js
+++ b/test/d_count_transfer_manager.js
@@ -311,6 +311,9 @@ contract("CountTransferManager", async (accounts) => {
             );
 
             await catchRevert(I_SecurityToken.issue(account_investor3, new BN(web3.utils.toWei("3", "ether")), "0x0", { from: token_owner }));
+            await catchRevert(I_SecurityToken.transfer(account_investor3, new BN(web3.utils.toWei("1", "ether")), { from: account_investor2 }));
+            let canTransfer = await I_SecurityToken.canTransfer(account_investor3, new BN(web3.utils.toWei("1", "ether")), "0x0", { from: account_investor2 });
+            assert.equal(canTransfer[0], "0x50"); //Transfer failure.
         });
 
         it("Should still be able to add to original token holders", async () => {

--- a/test/f_ether_dividends.js
+++ b/test/f_ether_dividends.js
@@ -350,8 +350,7 @@ contract("EtherDividendCheckpoint", async (accounts) => {
 
         it("Should not allow reclaiming withholding tax with incorrect index", async () => {
             await catchRevert(
-                I_EtherDividendCheckpoint.withdrawWithholding(300, { from: token_owner, gasPrice: 0 }),
-                "tx -> failed because dividend index is not valid"
+                I_EtherDividendCheckpoint.withdrawWithholding(300, { from: token_owner, gasPrice: 0 })
             );
         });
 
@@ -580,8 +579,7 @@ contract("EtherDividendCheckpoint", async (accounts) => {
                 I_EtherDividendCheckpoint.createDividendWithCheckpointAndExclusions(maturity, expiry, 4, addresses, dividendName, {
                     from: token_owner,
                     value: new BN(web3.utils.toWei("10", "ether"))
-                }),
-                "tx -> failed because too many address excluded"
+                })
             );
         });
 

--- a/test/helpers/exceptions.js
+++ b/test/helpers/exceptions.js
@@ -22,8 +22,8 @@ async function tryCatch(promise, message) {
 }
 
 module.exports = {
-    catchRevert: async function(promise) {
-        await tryCatch(promise, "revert");
+    catchRevert: async function(promise, message) {
+        await tryCatch(promise, message ? `revert ${message}` : "revert");
     },
     catchPermission: async function(promise) {
         await tryCatch(promise, "revert Permission check failed");

--- a/test/k_module_registry.js
+++ b/test/k_module_registry.js
@@ -155,8 +155,7 @@ contract("ModuleRegistry", async (accounts) => {
             catchRevert(
                 I_ModuleRegistryProxy.upgradeToAndCall("1.0.0", I_ModuleRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because polymathRegistry address is 0x"
+                })
             );
         });
 
@@ -165,8 +164,7 @@ contract("ModuleRegistry", async (accounts) => {
             catchRevert(
                 I_ModuleRegistryProxy.upgradeToAndCall("1.0.0", I_ModuleRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because owner address is 0x"
+                })
             );
         });
 
@@ -175,8 +173,7 @@ contract("ModuleRegistry", async (accounts) => {
             catchRevert(
                 I_ModuleRegistryProxy.upgradeToAndCall("1.0.0", I_ModuleRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because all params are 0x"
+                })
             );
         });
 

--- a/test/n_security_token_registry.js
+++ b/test/n_security_token_registry.js
@@ -193,8 +193,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because polymathRegistry address is 0x"
+                })
             );
         });
 
@@ -209,8 +208,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because owner address is 0x"
+                })
             );
         });
 
@@ -219,8 +217,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_SecurityTokenRegistryProxy.upgradeToAndCall("1.0.0", I_SecurityTokenRegistry.address, bytesProxy, {
                     from: account_polymath
-                }),
-                "tx-> revert because owner address is 0x"
+                })
             );
         });
 
@@ -287,15 +284,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
                     initRegFee,
                     account_polymath,
                     I_STRGetter.address
-                ),
-                "tx revert -> Can't call the initialize function again"
+                )
             );
         });
 
         it("Should fail to register ticker if tickerRegFee not approved", async () => {
             await catchRevert(
-                I_STRProxied.registerNewTicker(account_temp, symbol, { from: account_temp }),
-                "tx revert -> POLY allowance not provided for registration fee"
+                I_STRProxied.registerNewTicker(account_temp, symbol, { from: account_temp })
             );
         });
 
@@ -304,19 +299,17 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: account_temp });
 
             await catchRevert(
-                I_STRProxied.registerNewTicker(address_zero, symbol, { from: account_temp }),
-                "tx revert -> owner should not be 0x"
+                I_STRProxied.registerNewTicker(address_zero, symbol, { from: account_temp })
             );
         });
 
         it("Should fail to register ticker due to the symbol length is 0", async () => {
-            await catchRevert(I_STRProxied.registerNewTicker(account_temp, "", { from: account_temp }), "tx revert -> Symbol Length is 0");
+            await catchRevert(I_STRProxied.registerNewTicker(account_temp, "", { from: account_temp }));
         });
 
         it("Should fail to register ticker due to the symbol length is greater than 10", async () => {
             await catchRevert(
-                I_STRProxied.registerNewTicker(account_temp, "POLYMATHNET", { from: account_temp }),
-                "tx revert -> Symbol Length is greater than 10"
+                I_STRProxied.registerNewTicker(account_temp, "POLYMATHNET", { from: account_temp })
             );
         });
 
@@ -400,8 +393,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: token_owner });
             // Call registration function
             await catchRevert(
-                I_STRProxied.registerNewTicker(token_owner, symbol, { from: token_owner }),
-                "tx revert -> Symbol is already alloted to someone else"
+                I_STRProxied.registerNewTicker(token_owner, symbol, { from: token_owner })
             );
         });
 
@@ -418,13 +410,12 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: token_owner });
 
             await catchRevert(
-                I_STRProxied.registerNewTicker(token_owner, "AAA", { from: token_owner }),
-                "tx revert -> Registration is paused"
+                I_STRProxied.registerNewTicker(token_owner, "AAA", { from: token_owner })
             );
         });
 
         it("Should fail to pause if already paused", async () => {
-            await catchRevert(I_STRProxied.pause({ from: account_polymath }), "tx revert -> Registration is already paused");
+            await catchRevert(I_STRProxied.pause({ from: account_polymath }));
         });
 
         it("Should successfully register ticker if registration is unpaused", async () => {
@@ -436,13 +427,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
         });
 
         it("Should fail to unpause if already unpaused", async () => {
-            await catchRevert(I_STRProxied.unpause({ from: account_polymath }), "tx revert -> Registration is already unpaused");
+            await catchRevert(I_STRProxied.unpause({ from: account_polymath }));
         });
     });
 
     describe("Test cases for the expiry limit", async () => {
         it("Should fail to set the expiry limit because msg.sender is not owner", async () => {
-            await catchRevert(I_STRProxied.changeExpiryLimit(duration.days(10), { from: account_temp }), "tx revert -> msg.sender is not owner");
+            await catchRevert(I_STRProxied.changeExpiryLimit(duration.days(10), { from: account_temp }));
         });
 
         it("Should successfully set the expiry limit", async () => {
@@ -456,8 +447,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
 
         it("Should fail to set the expiry limit because new expiry limit is lesser than one day", async () => {
             await catchRevert(
-                I_STRProxied.changeExpiryLimit(duration.seconds(5000), { from: account_polymath }),
-                "tx revert -> New expiry limit is lesser than one day"
+                I_STRProxied.changeExpiryLimit(duration.seconds(5000), { from: account_polymath })
             );
         });
     });
@@ -493,8 +483,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_PolyToken.approve(I_STRProxied.address, new BN(0), { from: token_owner });
 
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: token_owner }),
-                "tx revert -> POLY allowance not provided for registration fee"
+                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: token_owner })
             );
         });
 
@@ -503,8 +492,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: token_owner });
 
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: token_owner }),
-                "tx revert -> Registration is paused"
+                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: token_owner })
             );
         });
 
@@ -512,36 +500,31 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await I_STRProxied.unpause({ from: account_polymath });
 
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, "0x0", tokenDetails, false, token_owner, 0, { from: token_owner }),
-                "tx revert -> Zero ticker length is not allowed"
+                I_STRProxied.generateNewSecurityToken(name, "0x0", tokenDetails, false, token_owner, 0, { from: token_owner })
             );
         });
 
         it("Should fail to generate the securityToken -- Because name length is 0", async () => {
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken("", symbol, tokenDetails, false, token_owner, 0, { from: token_owner }),
-                "tx revert -> 0 name length is not allowed"
+                I_STRProxied.generateNewSecurityToken("", symbol, tokenDetails, false, token_owner, 0, { from: token_owner })
             );
         });
 
         it("Should fail to generate the securityToken -- Because version is not valid", async () => {
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken("", symbol, tokenDetails, false, token_owner, 12356, { from: token_owner }),
-                "tx revert -> 0 name length is not allowed"
+                I_STRProxied.generateNewSecurityToken("", symbol, tokenDetails, false, token_owner, 12356, { from: token_owner })
             );
         });
 
         it("Should fail to generate the securityToken -- Because treasury wallet is 0x0", async () => {
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, address_zero, 0, { from: token_owner }),
-                "tx revert -> 0x0 value of treasury wallet is not allowed"
+                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, address_zero, 0, { from: token_owner })
             );
         });
 
         it("Should fail to generate the securityToken -- Because msg.sender is not the rightful owner of the ticker", async () => {
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: account_temp }),
-                "tx revert -> Because msg.sender is not the rightful owner of the ticker"
+                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, token_owner, 0, { from: account_temp })
             );
         });
 
@@ -569,8 +552,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
 
         it("Should fail to generate the SecurityToken when token is already deployed with the same symbol", async () => {
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, treasury_wallet, 0, { from: token_owner }),
-                "tx revert -> Because ticker is already in use"
+                I_STRProxied.generateNewSecurityToken(name, symbol, tokenDetails, false, treasury_wallet, 0, { from: token_owner })
             );
         });
 
@@ -580,8 +562,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             let tx = await I_STRProxied.registerNewTicker(token_owner, "CCC", { from: token_owner });
             await increaseTime(duration.days(65));
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken(name, "CCC", tokenDetails, false, treasury_wallet, 0, { from: token_owner }),
-                "tx revert -> Because ticker is expired"
+                I_STRProxied.generateNewSecurityToken(name, "CCC", tokenDetails, false, treasury_wallet, 0, { from: token_owner })
             );
             await revertToSnapshot(snap_Id);
         });
@@ -739,8 +720,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             ]);
 
             await catchRevert(
-                I_SecurityTokenRegistryProxy.upgradeToAndCall("1.1.0", I_SecurityTokenRegistryV2.address, bytesProxy, { from: account_temp }),
-                "tx revert -> bad owner"
+                I_SecurityTokenRegistryProxy.upgradeToAndCall("1.1.0", I_SecurityTokenRegistryV2.address, bytesProxy, { from: account_temp })
             );
         });
 
@@ -773,8 +753,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingSecurityToken("LOG", account_temp, dummy_token, "I am custom ST", currentTime, {
                     from: account_delegate
-                }),
-                "tx revert -> msg.sender is not polymath account"
+                })
             );
         });
 
@@ -782,8 +761,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingSecurityToken("LOGLOGLOGLOG", account_temp, dummy_token, "I am custom ST", currentTime, {
                     from: account_polymath
-                }),
-                "tx revert -> ticker length is greater than 10 chars"
+                })
             );
         });
 
@@ -791,8 +769,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingSecurityToken("LOG", account_temp, dummy_token, "I am custom ST", currentTime, {
                     from: account_polymath
-                }),
-                "tx revert -> name should not be 0 length"
+                })
             );
         });
 
@@ -800,8 +777,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingSecurityToken("LOG", account_temp, address_zero, "I am custom ST", currentTime, {
                     from: account_polymath
-                }),
-                "tx revert -> Security token address is 0"
+                })
             );
         });
 
@@ -809,15 +785,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingSecurityToken("0x0", account_temp, dummy_token, "I am custom ST", currentTime, {
                     from: account_polymath
-                }),
-                "tx revert -> zero length of the symbol is not allowed"
+                })
             );
         });
 
         it("Should fail to generate the custom ST -- deployedAt param is 0", async () => {
             await catchRevert(
-                I_STRProxied.modifyExistingSecurityToken(symbol2, token_owner, dummy_token, "I am custom ST", new BN(0), { from: account_polymath }),
-                "tx revert -> because deployedAt param is 0"
+                I_STRProxied.modifyExistingSecurityToken(symbol2, token_owner, dummy_token, "I am custom ST", new BN(0), { from: account_polymath })
             );
         });
 
@@ -883,8 +857,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingTicker(token_owner, "ETH", currentTime, currentTime.add(new BN(duration.days(10))), false, {
                     from: account_temp
-                }),
-                "tx revert -> failed beacause of bad owner0"
+                })
             );
         });
 
@@ -892,8 +865,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingTicker(token_owner, "", currentTime, currentTime.add(new BN(duration.days(10))), false, {
                     from: account_polymath
-                }),
-                "tx revert -> failed beacause ticker length should not be 0"
+                })
             );
         });
 
@@ -901,8 +873,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingTicker(token_owner, "ETH", new BN(0), currentTime.add(new BN(duration.days(10))), false, {
                     from: account_polymath
-                }),
-                "tx revert -> failed because time should not be 0"
+                })
             );
         });
 
@@ -911,8 +882,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             await catchRevert(
                 I_STRProxied.modifyExistingTicker(token_owner, "ETH", ctime, ctime.sub(new BN(duration.minutes(10))), false, {
                     from: account_polymath
-                }),
-                "tx revert -> failed because registeration date is greater than the expiryDate"
+                })
             );
         });
 
@@ -926,8 +896,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
                     ctime.add(new BN(duration.minutes(10))),
                     false,
                     { from: account_polymath }
-                ),
-                "tx revert -> failed because owner should not be 0x"
+                )
             );
         });
 
@@ -962,23 +931,20 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test cases for the transferTickerOwnership()", async () => {
         it("Should be able to transfer the ticker ownership -- failed because token is not deployed having the same ticker", async () => {
             await catchRevert(
-                I_STRProxied.transferTickerOwnership(account_issuer, "ETH", { from: account_temp }),
-                "tx revert -> failed because token is not deployed having the same ticker"
+                I_STRProxied.transferTickerOwnership(account_issuer, "ETH", { from: account_temp })
             );
         });
 
         it("Should be able to transfer the ticker ownership -- failed because new owner is 0x", async () => {
             //await I_SecurityToken002.transferOwnership(account_temp, { from: token_owner });
             await catchRevert(
-                I_STRProxied.transferTickerOwnership(address_zero, symbol2, { from: token_owner }),
-                "tx revert -> failed because new owner is 0x"
+                I_STRProxied.transferTickerOwnership(address_zero, symbol2, { from: token_owner })
             );
         });
 
         it("Should be able to transfer the ticker ownership -- failed because ticker is of zero length", async () => {
             await catchRevert(
-                I_STRProxied.transferTickerOwnership(account_temp, "", { from: token_owner }),
-                "tx revert -> failed because ticker is of zero length"
+                I_STRProxied.transferTickerOwnership(account_temp, "", { from: token_owner })
             );
         });
 
@@ -993,15 +959,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test case for the changeSecurityLaunchFee()", async () => {
         it("Should be able to change the STLaunchFee-- failed because of bad owner", async () => {
             await catchRevert(
-                I_STRProxied.changeSecurityLaunchFee(new BN(web3.utils.toWei("500")), { from: account_temp }),
-                "tx revert -> failed because of bad owner"
+                I_STRProxied.changeSecurityLaunchFee(new BN(web3.utils.toWei("500")), { from: account_temp })
             );
         });
 
         it("Should be able to change the STLaunchFee-- failed because of putting the same fee", async () => {
             await catchRevert(
-                I_STRProxied.changeSecurityLaunchFee(initRegFee, { from: account_polymath }),
-                "tx revert -> failed because of putting the same fee"
+                I_STRProxied.changeSecurityLaunchFee(initRegFee, { from: account_polymath })
             );
         });
 
@@ -1016,15 +980,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test cases for the changeExpiryLimit()", async () => {
         it("Should be able to change the ExpiryLimit-- failed because of bad owner", async () => {
             await catchRevert(
-                I_STRProxied.changeExpiryLimit(duration.days(15), { from: account_temp }),
-                "tx revert -> failed because of bad owner"
+                I_STRProxied.changeExpiryLimit(duration.days(15), { from: account_temp })
             );
         });
 
         it("Should be able to change the ExpiryLimit-- failed because expirylimit is less than 1 day", async () => {
             await catchRevert(
-                I_STRProxied.changeExpiryLimit(duration.minutes(50), { from: account_polymath }),
-                "tx revert -> failed because expirylimit is less than 1 day"
+                I_STRProxied.changeExpiryLimit(duration.minutes(50), { from: account_polymath })
             );
         });
 
@@ -1039,15 +1001,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test cases for the changeTickerRegistrationFee()", async () => {
         it("Should be able to change the fee currency-- failed because of bad owner", async () => {
             await catchRevert(
-                I_STRProxied.changeFeesAmountAndCurrency(new BN(web3.utils.toWei("500")), new BN(web3.utils.toWei("100")), false, { from: account_temp }),
-                "tx revert -> failed because of bad owner"
+                I_STRProxied.changeFeesAmountAndCurrency(new BN(web3.utils.toWei("500")), new BN(web3.utils.toWei("100")), false, { from: account_temp })
             );
         });
 
         it("Should be able to change the fee currency-- failed because of putting the same currency", async () => {
             await catchRevert(
-                I_STRProxied.changeFeesAmountAndCurrency(new BN(web3.utils.toWei("500")), new BN(web3.utils.toWei("100")), false, { from: account_polymath }),
-                "tx revert -> failed because of putting the same fee"
+                I_STRProxied.changeFeesAmountAndCurrency(new BN(web3.utils.toWei("500")), new BN(web3.utils.toWei("100")), false, { from: account_polymath })
             );
         });
 
@@ -1073,15 +1033,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test cases for the changeTickerRegistrationFee()", async () => {
         it("Should be able to change the TickerRegFee-- failed because of bad owner", async () => {
             await catchRevert(
-                I_STRProxied.changeTickerRegistrationFee(new BN(web3.utils.toWei("500")), { from: account_temp }),
-                "tx revert -> failed because of bad owner"
+                I_STRProxied.changeTickerRegistrationFee(new BN(web3.utils.toWei("500")), { from: account_temp })
             );
         });
 
         it("Should be able to change the TickerRegFee-- failed because of putting the same fee", async () => {
             await catchRevert(
-                I_STRProxied.changeTickerRegistrationFee(initRegFee, { from: account_polymath }),
-                "tx revert -> failed because of putting the same fee"
+                I_STRProxied.changeTickerRegistrationFee(initRegFee, { from: account_polymath })
             );
         });
 
@@ -1095,8 +1053,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
         it("Should fail to register the ticker with the old fee", async () => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: token_owner });
             await catchRevert(
-                I_STRProxied.registerNewTicker(token_owner, "POLY", { from: token_owner }),
-                "tx revert -> failed because of ticker registeration fee gets change"
+                I_STRProxied.registerNewTicker(token_owner, "POLY", { from: token_owner })
             );
         });
 
@@ -1111,8 +1068,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
         it("Should fail to launch the securityToken with the old launch fee", async () => {
             await I_PolyToken.approve(I_STRProxied.address, initRegFeePOLY, { from: token_owner });
             await catchRevert(
-                I_STRProxied.generateNewSecurityToken("Polymath", "POLY", tokenDetails, false, token_owner, 0,  { from: token_owner }),
-                "tx revert -> failed because of old launch fee"
+                I_STRProxied.generateNewSecurityToken("Polymath", "POLY", tokenDetails, false, token_owner, 0,  { from: token_owner })
             );
         });
 
@@ -1129,14 +1085,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
         it("Should change the polytoken address -- failed because of bad owner", async () => {
             catchRevert(
                 I_STRProxied.updatePolyTokenAddress(dummy_token, { from: account_temp }),
-                "tx revert -> failed because of bad owner"
+                "Only owner"
             );
         });
 
         it("Should change the polytoken address -- failed because of 0x address", async () => {
             catchRevert(
-                I_STRProxied.updatePolyTokenAddress(address_zero, { from: account_polymath }),
-                "tx revert -> failed because 0x address"
+                I_STRProxied.updatePolyTokenAddress(address_zero, { from: account_polymath })
             );
         });
 
@@ -1233,15 +1188,13 @@ contract("SecurityTokenRegistry", async (accounts) => {
     describe("Test case for the Removing the ticker", async () => {
         it("Should remove the ticker from the polymath ecosystem -- bad owner", async () => {
             await catchRevert(
-                I_STRProxied.removeTicker(symbol2, { from: account_investor1 }),
-                "tx revert -> failed because msg.sender should be account_polymath"
+                I_STRProxied.removeTicker(symbol2, { from: account_investor1 })
             );
         });
 
         it("Should remove the ticker from the polymath ecosystem -- fail because ticker doesn't exist in the ecosystem", async () => {
             await catchRevert(
-                I_STRProxied.removeTicker("HOLA", { from: account_polymath }),
-                "tx revert -> failed because ticker doesn't exist in the polymath ecosystem"
+                I_STRProxied.removeTicker("HOLA", { from: account_polymath })
             );
         });
 
@@ -1338,7 +1291,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
 
         describe("Test cases for pausing the contract", async () => {
             it("Should fail to pause if msg.sender is not owner", async () => {
-                await catchRevert(I_STRProxied.pause({ from: account_temp }), "tx revert -> msg.sender should be account_polymath");
+                await catchRevert(I_STRProxied.pause({ from: account_temp }));
             });
 
             it("Should successfully pause the contract", async () => {
@@ -1348,7 +1301,7 @@ contract("SecurityTokenRegistry", async (accounts) => {
             });
 
             it("Should fail to unpause if msg.sender is not owner", async () => {
-                await catchRevert(I_STRProxied.unpause({ from: account_temp }), "tx revert -> msg.sender should be account_polymath");
+                await catchRevert(I_STRProxied.unpause({ from: account_temp }));
             });
 
             it("Should successfully unpause the contract", async () => {

--- a/test/o_security_token.js
+++ b/test/o_security_token.js
@@ -388,7 +388,7 @@ contract("SecurityToken", async (accounts) => {
             let id = await takeSnapshot();
             await I_SecurityToken.freezeIssuance(freezeIssuanceAckHash, { from: token_owner });
             assert.isFalse(await stGetter.isIssuable.call());
-            await catchRevert(I_SecurityToken.issue(account_affiliate1, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner, gas: 500000 }));
+            await catchRevert(I_SecurityToken.issue(account_affiliate1, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner, gas: 500000 }), "Issuance frozen");
             await revertToSnapshot(id);
         });
 
@@ -396,7 +396,10 @@ contract("SecurityToken", async (accounts) => {
             startTime = await latestTime() + duration.seconds(5000);
             endTime = startTime + duration.days(30);
             let bytesSTO = encodeModuleCall(STOParameters, [startTime, endTime, cap, rate, fundRaiseType, account_fundsReceiver]);
-            await catchRevert(I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, new BN(0), false, { from: token_owner }));
+            await catchRevert(
+                I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, maxCost, new BN(0), false, { from: token_owner }),
+                "Insufficient tokens transferable"
+            );
         });
 
         it("Should fail to attach the STO factory because max cost too small", async () => {
@@ -407,7 +410,8 @@ contract("SecurityToken", async (accounts) => {
             await I_PolyToken.transfer(I_SecurityToken.address, cappedSTOSetupCostPOLY, { from: token_owner });
 
             await catchRevert(
-                I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, new BN(web3.utils.toWei("1000", "ether")), new BN(0), false, { from: token_owner })
+                I_SecurityToken.addModule(I_CappedSTOFactory.address, bytesSTO, new BN(web3.utils.toWei("1000", "ether")), new BN(0), false, { from: token_owner }),
+                "Invalid cost"
             );
         });
 
@@ -511,12 +515,20 @@ contract("SecurityToken", async (accounts) => {
             await catchRevert(I_SecurityToken.removeModule(I_GeneralTransferManager.address, { from: account_delegate }));
         });
 
-        it("Should fail to remove the module - module not archived", async () => {
+
+        it("Should fail to remove the module - only owner", async () => {
             await catchRevert(I_SecurityToken.removeModule(I_GeneralTransferManager.address, { from: account_temp }));
         });
 
         it("Should fail to remove the module - incorrect address", async () => {
-            await catchRevert(I_SecurityToken.removeModule(address_zero, { from: token_owner }));
+            await catchRevert(I_SecurityToken.removeModule(address_zero, { from: token_owner }), "Not archived");
+        });
+
+        it("Should fail to remove the module - not archived", async () => {
+            await catchRevert(
+                I_SecurityToken.removeModule(I_GeneralTransferManager.address, { from: token_owner }),
+                "Not archived"
+            );
         });
 
         it("Should successfully remove the general transfer manager module from the securityToken", async () => {
@@ -557,7 +569,7 @@ contract("SecurityToken", async (accounts) => {
         it("Should successfully archive the module first and fail during achiving the module again", async () => {
             let key = await takeSnapshot();
             await I_SecurityToken.archiveModule(I_GeneralTransferManager.address, { from: token_owner });
-            await catchRevert(I_SecurityToken.archiveModule(I_GeneralTransferManager.address, { from: token_owner }));
+            await catchRevert(I_SecurityToken.archiveModule(I_GeneralTransferManager.address, { from: token_owner }), "Module archived");
             await revertToSnapshot(key);
         });
 
@@ -578,8 +590,8 @@ contract("SecurityToken", async (accounts) => {
             assert.equal(moduleData[3], true);
         });
 
-        it("Should fail to issue (or transfer) tokens while all TM are archived archived", async () => {
-            await catchRevert(I_SecurityToken.issue(one_address, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner }));
+        it("Should fail to issue (or transfer) tokens while all TM are archived", async () => {
+            await catchRevert(I_SecurityToken.issue(one_address, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner }), "Transfer Invalid");
         });
 
         it("Should successfully unarchive the general transfer manager module from the securityToken", async () => {
@@ -594,19 +606,19 @@ contract("SecurityToken", async (accounts) => {
         });
 
         it("Should successfully unarchive the general transfer manager module from the securityToken -- fail because module is already unarchived", async () => {
-            await catchRevert(I_SecurityToken.unarchiveModule(I_GeneralTransferManager.address, { from: token_owner }));
+            await catchRevert(I_SecurityToken.unarchiveModule(I_GeneralTransferManager.address, { from: token_owner }), "Module unarchived");
         });
 
         it("Should successfully archive the module -- fail because module is not existed", async () => {
-            await catchRevert(I_SecurityToken.archiveModule(I_GeneralPermissionManagerFactory.address, { from: token_owner }));
+            await catchRevert(I_SecurityToken.archiveModule(I_GeneralPermissionManagerFactory.address, { from: token_owner }), "Module missing");
         });
 
         it("Should fail to issue tokens while GTM unarchived", async () => {
-            await catchRevert(I_SecurityToken.issue(one_address, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner, gas: 500000 }));
+            await catchRevert(I_SecurityToken.issue(one_address, new BN(100).mul(new BN(10).pow(new BN(18))), "0x0", { from: token_owner, gas: 500000 }), "Transfer Invalid");
         });
 
         it("Should change the budget of the module - fail incorrect address", async () => {
-            await catchRevert(I_SecurityToken.changeModuleBudget(address_zero, new BN(100).mul(new BN(10).pow(new BN(18))), true, { from: token_owner }));
+            await catchRevert(I_SecurityToken.changeModuleBudget(address_zero, new BN(100).mul(new BN(10).pow(new BN(18))), true, { from: token_owner }), "Module missing");
         });
 
         it("Should change the budget of the module", async () => {
@@ -669,19 +681,20 @@ contract("SecurityToken", async (accounts) => {
 
             assert.equal(_canTransfer[0], 0x50);
 
-            await catchRevert(I_SecurityToken.transfer(account_investor2, new BN(10).mul(new BN(10).pow(new BN(18))), { from: account_investor1 }));
+            await catchRevert(I_SecurityToken.transfer(account_investor2, new BN(10).mul(new BN(10).pow(new BN(18))), { from: account_investor1 }),
+                "Transfer Invalid");
         });
 
-        it("Should fail to provide the permission to the delegate to change the transfer bools -- Bad owner", async () => {
+        it("Should fail to provide the permission to the delegate to change the transfer bools -- invalid permission", async () => {
             // Add permission to the deletgate (A regesteration process)
             await I_SecurityToken.addModule(I_GeneralPermissionManagerFactory.address, "0x0", new BN(0), new BN(0), false, { from: token_owner });
             let moduleData = (await stGetter.getModulesByType(permissionManagerKey))[0];
             I_GeneralPermissionManager = await GeneralPermissionManager.at(moduleData);
-            await catchRevert(I_GeneralPermissionManager.addDelegate(account_delegate, delegateDetails, { from: account_temp }));
+            await catchRevert(I_GeneralPermissionManager.addDelegate(account_delegate, delegateDetails, { from: account_temp }), "Invalid permission");
         });
 
         it("Should provide the permission to the delegate to change the transfer bools", async () => {
-            // Add permission to the deletgate (A regesteration process)
+            // Add permission to the deletgate (A registeration process)
             await I_GeneralPermissionManager.addDelegate(account_delegate, delegateDetails, { from: token_owner });
             assert.isTrue(await I_GeneralPermissionManager.checkDelegate.call(account_delegate));
             // Providing the permission to the delegate
@@ -710,11 +723,11 @@ contract("SecurityToken", async (accounts) => {
         });
 
         it("Should fail to send tokens with the wrong granularity", async () => {
-            await catchRevert(I_SecurityToken.transfer(accounts[7], new BN(10).pow(new BN(17)), { from: account_investor1 }));
+            await catchRevert(I_SecurityToken.transfer(accounts[7], new BN(10).pow(new BN(17)), { from: account_investor1 }), "Invalid granularity");
         });
 
         it("Should not allow 0 granularity", async () => {
-            await catchRevert(I_SecurityToken.changeGranularity(0, { from: token_owner }));
+            await catchRevert(I_SecurityToken.changeGranularity(0, { from: token_owner }), "Invalid granularity");
         });
 
         it("Should adjust granularity", async () => {
@@ -728,7 +741,7 @@ contract("SecurityToken", async (accounts) => {
         });
 
         it("Should not allow 0x0 address as data store", async () => {
-            await catchRevert(I_SecurityToken.changeDataStore(address_zero, { from: token_owner }));
+            await catchRevert(I_SecurityToken.changeDataStore(address_zero, { from: token_owner }), "Invalid address");
         });
 
         it("Should change data store", async () => {
@@ -757,7 +770,7 @@ contract("SecurityToken", async (accounts) => {
             await revertToSnapshot(ID_snap);
         });
 
-        it("Should activate allow All Whitelist Transfers", async () => {
+        it("Should activate Allow All Whitelist Transfers", async () => {
             ID_snap = await takeSnapshot();
             await I_GeneralTransferManager.modifyTransferRequirementsMulti(
                 [0, 1, 2],
@@ -929,7 +942,7 @@ contract("SecurityToken", async (accounts) => {
         });
 
         it("Should Fail in trasferring from whitelist investor1 to non-whitelist investor", async () => {
-            await catchRevert(I_SecurityToken.transfer(account_temp, new BN(10).mul(new BN(10).pow(new BN(18))), { from: account_investor1, gas: 2500000 }));
+            await catchRevert(I_SecurityToken.transfer(account_temp, new BN(10).mul(new BN(10).pow(new BN(18))), { from: account_investor1, gas: 2500000 }), "Transfer Invalid");
             await revertToSnapshot(ID_snap);
         });
 
@@ -997,7 +1010,8 @@ contract("SecurityToken", async (accounts) => {
                     to: I_CappedSTO.address,
                     gas: 2100000,
                     value: new BN(web3.utils.toWei("1", "ether"))
-                })
+                }),
+                "Issuance frozen"
             );
             await revertToSnapshot(id);
         });
@@ -1018,7 +1032,8 @@ contract("SecurityToken", async (accounts) => {
                     to: I_CappedSTO.address,
                     gas: 2100000,
                     value: new BN(web3.utils.toWei("1", "ether"))
-                })
+                }),
+                "Transfer Invalid"
             );
         });
 
@@ -1027,7 +1042,7 @@ contract("SecurityToken", async (accounts) => {
             assert.isTrue(tx.logs[0].args._status);
         });
 
-        it("Should fail to freeze the transfers", async () => {
+        it("Should fail to freeze already frozen transfers", async () => {
             await catchRevert(I_SecurityToken.freezeTransfers({ from: token_owner }));
         });
 
@@ -1045,12 +1060,13 @@ contract("SecurityToken", async (accounts) => {
                     to: I_CappedSTO.address,
                     gas: 2100000,
                     value: new BN(web3.utils.toWei("1", "ether"))
-                })
+                }),
+                "Transfer Invalid"
             );
         });
 
         it("Should fail in trasfering the tokens from one user to another", async () => {
-            await catchRevert(I_SecurityToken.transfer(account_investor1, new BN(web3.utils.toWei("1", "ether")), { from: account_temp }));
+            await catchRevert(I_SecurityToken.transfer(account_investor1, new BN(web3.utils.toWei("1", "ether")), { from: account_temp }), "Transfer Invalid");
         });
 
         it("Should unfreeze all the transfers", async () => {
@@ -1058,7 +1074,7 @@ contract("SecurityToken", async (accounts) => {
             assert.isFalse(tx.logs[0].args._status);
         });
 
-        it("Should freeze the transfers", async () => {
+        it("Should fail to ufreeze the already unfrozen transfers", async () => {
             await catchRevert(I_SecurityToken.unfreezeTransfers({ from: token_owner }));
         });
 
@@ -1123,7 +1139,7 @@ contract("SecurityToken", async (accounts) => {
             await catchRevert(
                 I_SecurityToken.controllerRedeem(account_temp, currentBalance + new BN(web3.utils.toWei("500", "ether")), "0x0", "0x0", {
                     from: account_controller
-                })
+                }),
             );
         });
         it("Should force burn the tokens - wrong caller", async () => {
@@ -1133,13 +1149,12 @@ contract("SecurityToken", async (accounts) => {
                 console.log(investors[i]);
                 console.log(web3.utils.fromWei((await I_SecurityToken.balanceOf(investors[i])).toString()));
             }
-            await catchRevert(I_SecurityToken.controllerRedeem(account_temp, currentBalance, "0x0", "0x0", { from: token_owner }));
+            await catchRevert(I_SecurityToken.controllerRedeem(account_temp, currentBalance, "0x0", "0x0", { from: token_owner }), "Not Authorised");
         });
 
         it("Should burn the tokens", async () => {
             let currentInvestorCount = await I_SecurityToken.holderCount.call();
             let currentBalance = await I_SecurityToken.balanceOf(account_temp);
-            let investors = await stGetter.getInvestors.call();
             let tx = await I_SecurityToken.controllerRedeem(account_temp, currentBalance, "0x0", "0x0", { from: account_controller });
             // console.log(tx.logs[1].args._value.toNumber(), currentBalance.toNumber());
             assert.equal(tx.logs[1].args._value.toString(), currentBalance.toString());
@@ -1204,7 +1219,7 @@ contract("SecurityToken", async (accounts) => {
             assert.equal(filteredInvestors.length, 4);
         });
 
-        it("Should check the balance of investor at checkpoint", async () => {
+        it("Should fail to check the balance of investor at a non-existent checkpoint", async () => {
             await catchRevert(stGetter.balanceOfAt(account_investor1, 5));
         });
 
@@ -1272,7 +1287,7 @@ contract("SecurityToken", async (accounts) => {
                 }
             );
             assert.equal(tx.logs[0].args._investor, I_MockRedemptionManagerWrong.address, "Failed in adding the investor in whitelist");
-            // Provide approval to trnafer the tokens to Module
+            // Provide approval to transfer the tokens to Module
             await I_SecurityToken.approve(I_MockRedemptionManagerWrong.address, new BN(web3.utils.toWei("500")), { from: account_investor1 });
             // Transfer the tokens to module (Burn)
             await I_MockRedemptionManagerWrong.transferToRedeem(new BN(web3.utils.toWei("500")), { from: account_investor1 });
@@ -1293,7 +1308,7 @@ contract("SecurityToken", async (accounts) => {
             );
         });
 
-        it("Should successfully withdraw the poly", async () => {
+        it("Should fail to withdraw the poly - only owner", async () => {
             await catchRevert(
                 I_SecurityToken.withdrawERC20(I_PolyToken.address, new BN(web3.utils.toWei("20000", "ether")), { from: account_temp })
             );
@@ -1312,8 +1327,10 @@ contract("SecurityToken", async (accounts) => {
             );
         });
 
-        it("Should successfully withdraw the poly", async () => {
-            await catchRevert(I_SecurityToken.withdrawERC20(I_PolyToken.address, new BN(web3.utils.toWei("10", "ether")), { from: token_owner }));
+        it("Should fail to withdraw the poly - not enough Poly balance", async () => {
+            await catchRevert(
+                I_SecurityToken.withdrawERC20(I_PolyToken.address, new BN(web3.utils.toWei("10", "ether")), { from: token_owner })
+            );
         });
     });
 
@@ -1496,7 +1513,8 @@ contract("SecurityToken", async (accounts) => {
                     {
                         from: account_investor1
                     }
-                )
+                ),
+                "Invalid partition"
             )
 
             assert.equal(
@@ -1556,7 +1574,8 @@ contract("SecurityToken", async (accounts) => {
                     {
                         from: account_delegate
                     }
-                )
+                ),
+                "Invalid partition"
             );
         });
 
@@ -1572,7 +1591,8 @@ contract("SecurityToken", async (accounts) => {
                     {
                         from: account_affiliate1
                     }
-                )
+                ),
+                "Not Authorised"
             );
         });
 
@@ -1634,7 +1654,8 @@ contract("SecurityToken", async (accounts) => {
 
         it("Should fail to execute authorizeOperatorByPartition successfully for invalid partition", async() => {
             await catchRevert(
-                I_SecurityToken.authorizeOperatorByPartition(web3.utils.toHex("LOCKED"), account_delegate, {from: account_investor1})
+                I_SecurityToken.authorizeOperatorByPartition(web3.utils.toHex("LOCKED"), account_delegate, {from: account_investor1}),
+                "Invalid partition"
             );
         });
 
@@ -1677,7 +1698,8 @@ contract("SecurityToken", async (accounts) => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Invalid partition"
             );
         });
 
@@ -1737,7 +1759,8 @@ contract("SecurityToken", async (accounts) => {
         it("Should failed to redeem tokens by partition -- because not sufficient allowance", async() => {
             await I_SecurityToken.unarchiveModule(I_MockRedemptionManager.address, {from: token_owner});
             await catchRevert(
-                I_MockRedemptionManager.redeemTokensByPartition(new BN(web3.utils.toWei("10")), web3.utils.toHex("LOCKED"), "0x0", {from: account_investor1})
+                I_MockRedemptionManager.redeemTokensByPartition(new BN(web3.utils.toWei("10")), web3.utils.toHex("LOCKED"), "0x0", {from: account_investor1}),
+                "Invalid partition"
             );
         })
 
@@ -1747,7 +1770,8 @@ contract("SecurityToken", async (accounts) => {
 
             // failed because of invalid partition
             await catchRevert(
-                I_MockRedemptionManager.redeemTokensByPartition(new BN(web3.utils.toWei("10")), web3.utils.toHex("LOCKED"), "0x0", {from: account_investor1})
+                I_MockRedemptionManager.redeemTokensByPartition(new BN(web3.utils.toWei("10")), web3.utils.toHex("LOCKED"), "0x0", {from: account_investor1}),
+                "Invalid partition"
             );
         });
 
@@ -1799,7 +1823,8 @@ contract("SecurityToken", async (accounts) => {
                     {
                         from: account_investor1
                     }
-                )
+                ),
+                "Invalid partition"
             );
         });
 
@@ -2043,13 +2068,15 @@ contract("SecurityToken", async (accounts) => {
 
             it("\tShould failed to set a document details as name is empty\n", async() => {
                 await catchRevert(
-                    I_SecurityToken.setDocument(web3.utils.utf8ToHex(""), "https://www.gogl.bts.fly", "0x0", {from: token_owner})
+                    I_SecurityToken.setDocument(web3.utils.utf8ToHex(""), "https://www.gogl.bts.fly", "0x0", {from: token_owner}),
+                    "Bad name"
                 );
             });
 
             it("\tShould failed to set a document details as URI is empty\n", async() => {
                 await catchRevert(
-                    I_SecurityToken.setDocument(web3.utils.utf8ToHex("doc1"), "", "0x0", {from: token_owner})
+                    I_SecurityToken.setDocument(web3.utils.utf8ToHex("doc1"), "", "0x0", {from: token_owner}),
+                    "Bad uri"
                 );
             });
 
@@ -2079,7 +2106,7 @@ contract("SecurityToken", async (accounts) => {
 
         describe("Test cases for the getters functions\n", async()=> {
 
-                it("\tShould get the details of existed document\n", async() => {
+                it("\tShould get the details of an existing document\n", async() => {
                     let doc1Details = await stGetter.getDocument.call(web3.utils.utf8ToHex("doc1"));
                     assert.equal(doc1Details[0], uri);
                     assert.equal(web3.utils.toUtf8(doc1Details[1]), web3.utils.toUtf8(docHash));
@@ -2091,7 +2118,7 @@ contract("SecurityToken", async (accounts) => {
                     assert.closeTo(doc2Details[2].toNumber(), await latestTime(), 2);
                 });
 
-                it("\tShould get the details of the non-existed document it means every value should be zero\n", async() => {
+                it("\tShould get the details of the non-existent document it means every value should be zero\n", async() => {
                     let doc3Details = await stGetter.getDocument.call(web3.utils.utf8ToHex("doc3"));
                     assert.equal(doc3Details[0], "");
                     assert.equal(web3.utils.toUtf8(doc3Details[1]), "");
@@ -2109,15 +2136,16 @@ contract("SecurityToken", async (accounts) => {
 
         describe("Test cases for the removeDocument()\n", async() => {
 
-            it("\tShould failed to remove document because msg.sender is not authorised\n", async() => {
+            it("\tShould fail to remove document because msg.sender is not authorised\n", async() => {
                 await catchRevert(
                     I_SecurityToken.removeDocument(web3.utils.utf8ToHex("doc2"), {from: account_temp})
                 );
             });
 
-            it("\tShould failed to remove the document that is not existed in the contract\n", async() => {
+            it("\tShould fail to remove the document that doesn't exist in the contract\n", async() => {
                 await catchRevert(
-                    I_SecurityToken.removeDocument(web3.utils.utf8ToHex("doc3"), {from: token_owner})
+                    I_SecurityToken.removeDocument(web3.utils.utf8ToHex("doc3"), {from: token_owner}),
+                    "Not existed"
                 );
             });
 

--- a/test/y_volume_restriction_tm.js
+++ b/test/y_volume_restriction_tm.js
@@ -1929,7 +1929,7 @@ contract('VolumeRestrictionTransferManager', accounts => {
             await increaseTime(duration.minutes(2));
 
             // sell tokens when user restriction changes from the default restriction to individual restriction
-            await catchRevert (I_SecurityToken.transfer(account_investor1, web3.utils.toWei("5")), {from: account_delegate2});
+            await catchRevert (I_SecurityToken.transfer(account_investor1, web3.utils.toWei("5"), {from: account_delegate2}));
 
             // allow to transact when the day limit is with in the restriction. default allow to transact maximum 5 tokens within
             // a given rolling period. 4 tokens are already sold here user trying to sell 1 more token on the same day

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,10 +262,6 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.4.1, async@^2.5.0:
   dependencies:
     lodash "^4.17.11"
 
-async@~0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-
 async@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
@@ -1703,10 +1699,6 @@ decompress@^4.0.0:
     make-dir "^1.0.0"
     pify "^2.3.0"
     strip-dirs "^2.0.0"
-
-deep-equal@~0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
 
 deep-equal@~1.0.1:
   version "1.0.1"
@@ -3223,10 +3215,6 @@ i18n@^0.8.3:
     mustache "*"
     sprintf-js ">=1.0.3"
 
-i@0.3.x:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/i/-/i-0.3.6.tgz#d96c92732076f072711b6b10fd7d4f65ad8ee23d"
-
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -4131,7 +4119,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4223,10 +4211,6 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-
 mz@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -4266,10 +4250,6 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-ncp@1.0.x:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-1.0.1.tgz#d15367e5cb87432ba117d2bf80fdf45aecfb4246"
 
 needle@^2.2.1:
   version "2.2.4"
@@ -4698,14 +4678,6 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkginfo@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
-
-pkginfo@0.x.x:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -4762,17 +4734,6 @@ promise@^8.0.0:
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.2.tgz#9dcd0672192c589477d56891271bdc27547ae9f0"
   dependencies:
     asap "~2.0.6"
-
-prompt@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.0.0.tgz#8e57123c396ab988897fb327fd3aedc3e735e4fe"
-  dependencies:
-    colors "^1.1.2"
-    pkginfo "0.x.x"
-    read "1.0.x"
-    revalidator "0.1.x"
-    utile "0.3.x"
-    winston "2.1.x"
 
 prop-types@^15.6.2:
   version "15.7.2"
@@ -4934,12 +4895,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-read@1.0.x:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
-  dependencies:
-    mute-stream "~0.0.4"
 
 readable-stream@^1.0.33:
   version "1.1.14"
@@ -5189,11 +5144,7 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-revalidator@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
-
-rimraf@2, rimraf@2.6.3, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.6.1:
+rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.6.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:
@@ -6269,17 +6220,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-utile@0.3.x:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/utile/-/utile-0.3.0.tgz#1352c340eb820e4d8ddba039a4fbfaa32ed4ef3a"
-  dependencies:
-    async "~0.9.0"
-    deep-equal "~0.2.1"
-    i "0.3.x"
-    mkdirp "0.x.x"
-    ncp "1.0.x"
-    rimraf "2.x.x"
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -6647,18 +6587,6 @@ wide-align@^1.1.0:
 window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
-
-winston@2.1.x:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.1.1.tgz#3c9349d196207fd1bdff9d4bc43ef72510e3a12e"
-  dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    pkginfo "0.3.x"
-    stack-trace "0.0.x"
 
 winston@^2.3.1:
   version "2.4.4"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] **N/A** The commit message follows our Submission guidelines
- [ ] **N/A** Tests for the changes have been added (for bug fixes / features)
- [ ] **N/A** Docs have been added / updated (for bug fixes / features)


### What kind of change does this PR introduce? 

Updating security token unit tests, so that `catchRevert` asserts that reversions are caused for the expected reasons.

Besides ST unit tests, erroneous reason messages have been removed from remaining tests, as they don't work as intended.

Finally, it seems that `yarn.lock` wasn't quite caught up with `package.json`. The former gets overridden every time I run `yarn install`. Hence, I added `yarn.lock` changes to this PR.

### What is the current behavior? 
**N/A**

### What is the new behavior?
As is.


### Does this PR introduce a breaking change?
(What changes might users need to make in their application due to this PR?)



### Any Other information:
