### PR TITLE
KeyStore support for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /build
 .npm-debug.log
 *.DS_Store
+keyStore
+keyStoreLocal
 privKey
 privKeyLocal
 coverage/


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our Submission guidelines

### What kind of change does this PR introduce? 
CLI new feature

### What is the current behavior? 
Currently CLI requires a private key stored in a local file

### What is the new behavior?
If there is no keyStore file, the CLI will guide users to create one, asking for their private key and a password to encrypt it. Once the file exists, CLI will require the password at the beginning of the script to start using it.

### Does this PR introduce a breaking change?
Yes

### Any Other information:
