### PR TITLE
MATM:enable retrieving original allowance

### DIFF
--- a/CLI/commands/IO/input.js
+++ b/CLI/commands/IO/input.js
@@ -92,7 +92,7 @@ function readStringNonEmpty(message, defaultValue) {
 function readStringNonEmptyWithMaxBinarySize(maxBinarySize, message, defaultValue) {
   return readlineSync.question(message, {
     limit: function (input) {
-      return input.length > 0 && getBinarySize(input) < maxBinarySize
+      return input.length > 0 && Buffer.byteLength(input, 'utf8') < maxBinarySize
     },
     limitMessage: `Must be a valid string with binary size less than ${maxBinarySize}`,
     defaultInput: defaultValue

--- a/CLI/commands/transfer_manager.js
+++ b/CLI/commands/transfer_manager.js
@@ -888,7 +888,7 @@ async function matmManage() {
   if (getApprovals.length > 0) {
     let options = []
     getApprovals.forEach((item) => {
-      options.push(`${web3.utils.toAscii(item.description)}\n    From: ${item.from}\n    To: ${item.to}\n    Amount: ${web3.utils.fromWei(item.allowance)} ${tokenSymbol}\n    Expiry date: ${moment.unix(item.expiryTime).format('MM/DD/YYYY HH:mm')}\n`)
+      options.push(`${web3.utils.toAscii(item.description)}\n    From: ${item.from}\n    To: ${item.to}\n    Initial amount: ${web3.utils.fromWei(item.initialAllowance)} ${tokenSymbol}\n    Remaining amount: ${web3.utils.fromWei(item.allowance)} ${tokenSymbol}\n    Expiry date: ${moment.unix(item.expiryTime).format('MM/DD/YYYY HH:mm')}\n`)
     })
 
     let index = readlineSync.keyInSelect(options, 'Select an existing approval: ', {
@@ -931,7 +931,7 @@ async function matmManage() {
 async function matmExplore() {
   let getApprovals = await getApprovalsArray();
   getApprovals.forEach((item) => {
-    printMatmRow(item.from, item.to, item.allowance, item.expiryTime, item.description);
+    printMatmRow(item.from, item.to, item.initialAllowance, item.allowance, item.expiryTime, item.description);
   })
 }
 
@@ -992,14 +992,14 @@ async function matmManageDecrease(selectedApproval) {
 async function matmManageTimeOrDescription(selectedApproval) {
   let { expiryTime, description } = readExpiryTimeAndDescription(selectedApproval);
 
-  let modifyManualApprovalAction = currentTransferManager.methods.modifyManualApproval(selectedApproval.from, selectedApproval.to, parseInt(expiryTime), selectedApproval.allowance, web3.utils.fromAscii(description), 2);
+  let modifyManualApprovalAction = currentTransferManager.methods.modifyManualApproval(selectedApproval.from, selectedApproval.to, parseInt(expiryTime), 0, web3.utils.fromAscii(description), 2);
   await common.sendTransaction(modifyManualApprovalAction);
   console.log(chalk.green(`The approval expiry time has been modified successfully!`));
 }
 
 function readExpiryTimeAndDescription(selectedApproval) {
   let expiryTime = parseInt(input.readNumberGreaterThan(0, `Enter the new expiry time (Unix Epoch time) until which the transfer is allowed or leave empty to keep the current (${selectedApproval.expiryTime}): `, selectedApproval.expiryTime));
-  let description = readlineSync.readStringNonEmptyWithMaxBinarySize(33, `Enter the new description for the manual approval or leave empty to keep the current (${web3.utils.toAscii(selectedApproval.description)}): `);
+  let description = input.readStringNonEmptyWithMaxBinarySize(33, `Enter the new description for the manual approval or leave empty to keep the current (${web3.utils.toAscii(selectedApproval.description)}): `);
   return { expiryTime, description };
 }
 
@@ -1022,14 +1022,15 @@ async function getApprovalsArray() {
   }
 }
 
-function printMatmRow(from, to, allowance, time, description) {
-  console.log(`\nDescription: ${web3.utils.toAscii(description)}\nFrom ${from} to ${to}\nAllowance: ${web3.utils.fromWei(allowance)}\nExpiry time: ${moment.unix(time).format('MMMM Do YYYY HH:mm')}\n`);
+function printMatmRow(from, to, initialAllowance, allowance, time, description) {
+  console.log(`\nDescription: ${web3.utils.toAscii(description)}\nFrom ${from} to ${to}\nInitial allowance: ${web3.utils.fromWei(initialAllowance)}\nRemaining allowance: ${web3.utils.fromWei(allowance)}\nExpiry time: ${moment.unix(time).format('MMMM Do YYYY HH:mm')}\n`);
 }
 
 async function getApprovals() {
-  function ApprovalDetail(_from, _to, _allowance, _expiryTime, _description) {
+  function ApprovalDetail(_from, _to, _initialAllowance, _allowance, _expiryTime, _description) {
     this.from = _from;
     this.to = _to;
+    this.initialAllowance = _initialAllowance;
     this.allowance = _allowance;
     this.expiryTime = _expiryTime;
     this.description = _description;
@@ -1038,15 +1039,16 @@ async function getApprovals() {
   let results = [];
   let approvalDetails = await currentTransferManager.methods.getAllApprovals().call();
   for (let i = 0; i < approvalDetails[0].length; i++) {
-    results.push(new ApprovalDetail(approvalDetails[0][i], approvalDetails[1][i], approvalDetails[2][i], approvalDetails[3][i], approvalDetails[4][i]));
+    results.push(new ApprovalDetail(approvalDetails[0][i], approvalDetails[1][i], approvalDetails[2][i], approvalDetails[3][i], approvalDetails[4][i], approvalDetails[5][i]));
   }
   return results;
 }
 
 async function getApprovalsToAnAddress(address) {
-  function ApprovalDetail(_from, _to, _allowance, _expiryTime, _description) {
+  function ApprovalDetail(_from, _to, _initialAllowance, _allowance, _expiryTime, _description) {
     this.from = _from;
     this.to = _to;
+    this.initialAllowance = _initialAllowance;
     this.allowance = _allowance;
     this.expiryTime = _expiryTime;
     this.description = _description;
@@ -1055,7 +1057,7 @@ async function getApprovalsToAnAddress(address) {
   let results = [];
   let approvals = await currentTransferManager.methods.getActiveApprovalsToUser(address).call();
   for (let i = 0; i < approvals[0].length; i++) {
-    results.push(new ApprovalDetail(approvals[0][i], approvals[1][i], approvals[2][i], approvals[3][i], approvals[4][i]));
+    results.push(new ApprovalDetail(approvals[0][i], approvals[1][i], approvals[2][i], approvals[3][i], approvals[4][i], approvals[5][i]));
   }
   return results;
 }

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
@@ -231,7 +231,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
                     allowance = allowance - _changeInAllowance;
                 }
             }
-            approval.approvedAllowance = allowance;
+            approval.initialAllowance = allowance;
             approval.allowance = allowance;
         }
         // Greedy storage technique
@@ -348,7 +348,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
 
         address[] memory from = new address[](counter);
         address[] memory to = new address[](counter);
-        uint256[] memory approvedAllowance = new uint256[](counter);
+        uint256[] memory initialAllowance = new uint256[](counter);
         uint256[] memory allowance = new uint256[](counter);
         uint256[] memory expiryTime = new uint256[](counter);
         bytes32[] memory description = new bytes32[](counter);
@@ -360,14 +360,14 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
 
                 from[counter]=approvals[i].from;
                 to[counter]=approvals[i].to;
-                approvedAllowance[counter]=approvals[i].approvedAllowance;
+                initialAllowance[counter]=approvals[i].initialAllowance;
                 allowance[counter]=approvals[i].allowance;
                 expiryTime[counter]=approvals[i].expiryTime;
                 description[counter]=approvals[i].description;
                 counter ++;
             }
         }
-        return (from, to, approvedAllowance, allowance, expiryTime, description);
+        return (from, to, initialAllowance, allowance, expiryTime, description);
     }
 
     /**
@@ -387,7 +387,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
             ManualApproval storage approval = approvals[index];
             return(
                 approval.expiryTime,
-                approval.approvedAllowance,
+                approval.initialAllowance,
                 approval.allowance,
                 approval.description
             );
@@ -414,7 +414,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
         uint256 approvalsLength = approvals.length;
         address[] memory from = new address[](approvalsLength);
         address[] memory to = new address[](approvalsLength);
-        uint256[] memory approvedAllowance = new uint256[](approvalsLength);
+        uint256[] memory initialAllowance = new uint256[](approvalsLength);
         uint256[] memory allowance = new uint256[](approvalsLength);
         uint256[] memory expiryTime = new uint256[](approvalsLength);
         bytes32[] memory description = new bytes32[](approvalsLength);
@@ -423,14 +423,14 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
 
             from[i]=approvals[i].from;
             to[i]=approvals[i].to;
-            approvedAllowance[i]=approvals[i].approvedAllowance;
+            initialAllowance[i]=approvals[i].initialAllowance;
             allowance[i]=approvals[i].allowance;
             expiryTime[i]=approvals[i].expiryTime;
             description[i]=approvals[i].description;
 
         }
 
-        return (from, to, approvedAllowance, allowance, expiryTime, description);
+        return (from, to, initialAllowance, allowance, expiryTime, description);
 
     }
 

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
@@ -228,13 +228,13 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
             } else {
                 // Allowance get decreased
                 if (_changeInAllowance >= allowance) {
-                    allowance = 0;
                     if (_changeInAllowance >= initialAllowance) {
                         initialAllowance = 0;
                     }
                     else {
-                        initialAllowance = initialAllowance.sub(_changeInAllowance.sub(allowance));
+                        initialAllowance = initialAllowance.sub(allowance);
                     }
+                    allowance = 0;
                 } else {
                     allowance = allowance.sub(_changeInAllowance);
                     initialAllowance = initialAllowance.sub(_changeInAllowance);

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
@@ -25,7 +25,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
         uint256 _expiryTime,
         uint256 _allowance,
         bytes32 _description,
-        address indexed _edittedBy
+        address indexed _editedBy
     );
 
     event RevokeManualApproval(

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManager.sol
@@ -215,6 +215,7 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
         index--; //Index is stored in an incremented form. 0 represnts non existant.
         ManualApproval storage approval = approvals[index];
         uint256 allowance = approval.allowance;
+        uint256 initialAllowance = approval.initialAllowance;
         uint256 expiryTime = approval.expiryTime;
         require(allowance != 0, "Approval has been exhausted");
         require(expiryTime > now, "Approval has expired");
@@ -223,16 +224,24 @@ contract ManualApprovalTransferManager is ManualApprovalTransferManagerStorage, 
             if (_increase) {
                 // Allowance get increased
                 allowance = allowance.add(_changeInAllowance);
+                initialAllowance = initialAllowance.add(_changeInAllowance);
             } else {
                 // Allowance get decreased
                 if (_changeInAllowance >= allowance) {
                     allowance = 0;
+                    if (_changeInAllowance >= initialAllowance) {
+                        initialAllowance = 0;
+                    }
+                    else {
+                        initialAllowance = initialAllowance.sub(_changeInAllowance.sub(allowance));
+                    }
                 } else {
-                    allowance = allowance - _changeInAllowance;
+                    allowance = allowance.sub(_changeInAllowance);
+                    initialAllowance = initialAllowance.sub(_changeInAllowance);
                 }
             }
-            approval.initialAllowance = allowance;
             approval.allowance = allowance;
+            approval.initialAllowance = initialAllowance;
         }
         // Greedy storage technique
         if (expiryTime != _expiryTime) {

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerFactory.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerFactory.sol
@@ -22,7 +22,7 @@ contract ManualApprovalTransferManagerFactory is UpgradableModuleFactory {
         bool _isCostInPoly
     )
         public
-        UpgradableModuleFactory("3.0.0", _setupCost, _logicContract, _polymathRegistry, _isCostInPoly)
+        UpgradableModuleFactory("3.0.1", _setupCost, _logicContract, _polymathRegistry, _isCostInPoly)
     {
         name = "ManualApprovalTransferManager";
         title = "Manual Approval Transfer Manager";
@@ -31,7 +31,7 @@ contract ManualApprovalTransferManagerFactory is UpgradableModuleFactory {
         tagsData.push("Manual Approval");
         tagsData.push("Transfer Restriction");
         compatibleSTVersionRange["lowerBound"] = VersionUtils.pack(uint8(3), uint8(0), uint8(0));
-        compatibleSTVersionRange["upperBound"] = VersionUtils.pack(uint8(3), uint8(0), uint8(0));
+        compatibleSTVersionRange["upperBound"] = VersionUtils.pack(uint8(3), uint8(0), uint8(1));
     }
 
     /**

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
@@ -9,8 +9,8 @@ contract ManualApprovalTransferManagerStorage {
     struct ManualApproval {
         address from;
         address to;
+        uint256 approvedAllowance;
         uint256 allowance;
-        uint256 remainingAllowance;
         uint256 expiryTime;
         bytes32 description;
     }

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
@@ -9,7 +9,7 @@ contract ManualApprovalTransferManagerStorage {
     struct ManualApproval {
         address from;
         address to;
-        uint256 approvedAllowance;
+        uint256 initialAllowance;
         uint256 allowance;
         uint256 expiryTime;
         bytes32 description;

--- a/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
+++ b/contracts/modules/TransferManager/MATM/ManualApprovalTransferManagerStorage.sol
@@ -10,6 +10,7 @@ contract ManualApprovalTransferManagerStorage {
         address from;
         address to;
         uint256 allowance;
+        uint256 remainingAllowance;
         uint256 expiryTime;
         bytes32 description;
     }

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -625,7 +625,7 @@ contract("ManualApprovalTransferManager", accounts => {
             let data = await I_ManualApprovalTransferManager.approvals.call(0);
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
-            assert.equal(data[2].toString(), web3.utils.toWei("5"));
+            assert.equal(data[2].toString(), web3.utils.toWei("6"));
             assert.equal(data[3].toString(), web3.utils.toWei("5"));
             assert.equal(data[4].toString(), expiryTimeMA);
             assert.equal(web3.utils.toUtf8(data[5]), "New Description");
@@ -656,7 +656,7 @@ contract("ManualApprovalTransferManager", accounts => {
             let data = await I_ManualApprovalTransferManager.approvals.call(0);
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
-            assert.equal(data[2].toString(), web3.utils.toWei("1"));
+            assert.equal(data[2].toString(), web3.utils.toWei("5"));
             assert.equal(data[3].toString(), web3.utils.toWei("1"));
             assert.equal(data[4].toString(), expiryTimeMA);
             assert.equal(web3.utils.toUtf8(data[5]), "New Description");

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -390,10 +390,10 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(tx[1][0], account_investor4);
             console.log("2");
             assert.equal(tx[2][0], web3.utils.toWei("3"));
-            console.log("3");
-            assert.equal(tx[3][0].toString(), approvalTime);
             console.log("4");
-            assert.equal(web3.utils.toUtf8(tx[4][0]), "DESCRIPTION");
+            assert.equal(tx[4][0].toString(), approvalTime);
+            console.log("5");
+            assert.equal(web3.utils.toUtf8(tx[5][0]), "DESCRIPTION");
         })
 
         it("Should fail to add the same manual approval for the same `_from` & `_to` address", async() => {

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -1000,7 +1000,7 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(desc, "Manage transfers using single approvals", "Wrong Module added");
             let title = await I_ManualApprovalTransferManagerFactory.title.call();
             assert.equal(title, "Manual Approval Transfer Manager", "Wrong Module added");
-            assert.equal(await I_ManualApprovalTransferManagerFactory.version.call(), "3.0.0");
+            assert.equal(await I_ManualApprovalTransferManagerFactory.version.call(), "3.0.1");
         });
 
         it("Should get the tags of the factory", async () => {

--- a/test/j_manual_approval_transfer_manager.js
+++ b/test/j_manual_approval_transfer_manager.js
@@ -1,7 +1,6 @@
 import latestTime from "./helpers/latestTime";
-import { duration, ensureException, promisifyLogWatch, latestBlock } from "./helpers/utils";
+import { duration } from "./helpers/utils";
 import { takeSnapshot, increaseTime, revertToSnapshot } from "./helpers/time";
-import { encodeProxyCall } from "./helpers/encodeCall";
 import { catchRevert } from "./helpers/exceptions";
 import { setUpPolymathNetwork, deployManualApprovalTMAndVerifyed, deployGPMAndVerifyed, deployCountTMAndVerifyed } from "./helpers/createInstances";
 
@@ -9,7 +8,6 @@ const SecurityToken = artifacts.require("./SecurityToken.sol");
 const GeneralTransferManager = artifacts.require("./GeneralTransferManager");
 const ManualApprovalTransferManager = artifacts.require("./ManualApprovalTransferManager");
 const CountTransferManager = artifacts.require("./CountTransferManager");
-const GeneralPermissionManager = artifacts.require("./GeneralPermissionManager");
 const STGetter = artifacts.require("./STGetter.sol");
 
 const Web3 = require("web3");
@@ -30,6 +28,8 @@ contract("ManualApprovalTransferManager", accounts => {
     let account_investor3;
     let account_investor4;
     let account_investor5;
+    let account_investor6;
+    let account_investor7;
 
     // investor Details
     let fromTime = latestTime();
@@ -97,6 +97,9 @@ contract("ManualApprovalTransferManager", accounts => {
         account_investor3 = accounts[8];
         account_investor4 = accounts[9];
         account_investor5 = accounts[5];
+        account_investor6 = accounts[2];
+        account_investor7 = accounts[3];
+
 
         // Step 1: Deploy the genral PM ecosystem
         let instances = await setUpPolymathNetwork(account_polymath, token_owner);
@@ -233,12 +236,13 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal((await I_SecurityToken.balanceOf(account_investor2)).toString(), web3.utils.toWei("10", "ether"));
         });
 
-        it("Should successfully attach the ManualApprovalTransferManager with the security token", async () => {
+        it("Should fail to attach the ManualApprovalTransferManager without sufficient tokens", async () => {
             await I_PolyToken.getTokens(web3.utils.toWei("2000", "ether"), token_owner);
             await catchRevert(
                 I_SecurityToken.addModule(P_ManualApprovalTransferManagerFactory.address, "0x0", web3.utils.toWei("2000", "ether"), 0, false, {
                     from: token_owner
-                })
+                }),
+                "Insufficient tokens transferable"
             );
         });
 
@@ -282,7 +286,8 @@ contract("ManualApprovalTransferManager", accounts => {
                     web3.utils.toWei("2", "ether"),
                     "0x0",
                     { from: token_owner }
-                )
+                ),
+                "Sender is not owner"
             );
         });
 
@@ -341,7 +346,22 @@ contract("ManualApprovalTransferManager", accounts => {
                     99999,
                     web3.utils.fromAscii("DESCRIPTION"),
                     { from: token_owner }
-                )
+                ),
+                "Invalid expiry time"
+            );
+        });
+
+        it("Should fail to add a manual approval because of invalid allowance", async () => {
+            await catchRevert(
+                I_ManualApprovalTransferManager.addManualApproval(
+                    account_investor1,
+                    account_investor4,
+                    0,
+                    currentTime.add(new BN(duration.days(1))),
+                    web3.utils.fromAscii("DESCRIPTION"),
+                    { from: token_owner }
+                ),
+                "Invalid allowance"
             );
         });
 
@@ -376,7 +396,7 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(web3.utils.toUtf8(tx[4][0]), "DESCRIPTION");
         })
 
-        it("Should try to add the same manual approval for the same `_from` & `_to` address", async() => {
+        it("Should fail to add the same manual approval for the same `_from` & `_to` address", async() => {
             await catchRevert(
                 I_ManualApprovalTransferManager.addManualApproval(
                     account_investor1,
@@ -387,7 +407,8 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Approval already exists"
             );
         })
 
@@ -418,12 +439,14 @@ contract("ManualApprovalTransferManager", accounts => {
 
         it("Should fail to sell the tokens more than the allowance", async() => {
             await catchRevert(
-                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("4"), {from: account_investor1})
+                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("4"), {from: account_investor1}),
+                "Transfer Invalid"
             );
         })
 
         it("Approval fails with wrong from to address", async () => {
-            await catchRevert(I_SecurityToken.transfer(account_investor5, web3.utils.toWei("1", "ether"), { from: account_investor1 }));
+            await catchRevert(I_SecurityToken.transfer(account_investor5, web3.utils.toWei("1", "ether"), { from: account_investor1 }),
+                "Transfer Invalid");
         });
 
         it("Should sell the tokens to investor 4 (GTM will give INVALID as investor 4 not in the whitelist)", async() => {
@@ -451,15 +474,16 @@ contract("ManualApprovalTransferManager", accounts => {
             await increaseTime(duration.days(1));
             currentTime = new BN(await latestTime());
             await catchRevert(
-                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("1"), {from: account_investor1})
+                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("1"), {from: account_investor1}),
+                "Transfer Invalid"
             );
         });
 
-        it("Should fail to modify the manual approval when the approval get expired", async() => {
+        it("Should fail to modify the manual approval when the approval doesn't exist", async() => {
             await catchRevert(
                 I_ManualApprovalTransferManager.modifyManualApproval(
-                    account_investor1,
-                    account_investor4,
+                    account_investor6,
+                    account_investor7,
                     currentTime.add(new BN(duration.days(2))),
                     web3.utils.toWei("5"),
                     web3.utils.fromAscii("New Description"),
@@ -467,7 +491,42 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Approval not present"
+            );
+        });
+
+        it("Should fail to modify the manual approval when the approval doesn't exist", async() => {
+            await catchRevert(
+                I_ManualApprovalTransferManager.modifyManualApproval(
+                    account_investor6,
+                    account_investor7,
+                    0,
+                    web3.utils.toWei("5"),
+                    web3.utils.fromAscii("New Description"),
+                    false,
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Invalid expiry time"
+            );
+        });
+
+        it("Should fail to modify the manual approval when the approval doesn't exist", async() => {
+            await catchRevert(
+                I_ManualApprovalTransferManager.modifyManualApproval(
+                    account_investor6,
+                    account_investor7,
+                    currentTime.add(new BN(duration.days(2))),
+                    web3.utils.toWei("5"),
+                    web3.utils.fromAscii("New Description"),
+                    false,
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Approval not present"
             );
         });
 
@@ -489,8 +548,27 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
             assert.equal(data[2], web3.utils.toWei("2"));
-            assert.equal(web3.utils.toUtf8(data[4]), "DESCRIPTION");
+            assert.equal(data[3], web3.utils.toWei("2"));
+            assert.equal(web3.utils.toUtf8(data[5]), "DESCRIPTION");
         });
+
+        it("Should set allowance to zero, if allowance is to be decreased to less than the current value", async () => {
+            const snapId = await takeSnapshot();
+            currentTime = new BN(await latestTime());
+            const tx = await I_ManualApprovalTransferManager.modifyManualApproval(
+                account_investor1,
+                account_investor4,
+                currentTime.add(new BN(duration.days(1))),
+                web3.utils.toWei("3"), // current allowance is 2 tokens.
+                web3.utils.fromAscii("New Description"),
+                false,
+                {
+                    from: token_owner
+                }
+            );
+            assert.equal((tx.logs[0].args._allowance).toString(), '0');
+            await revertToSnapshot(snapId);
+        })
 
         it("Should modify the manual approval expiry time for 4th investor", async () => {
             currentTime = new BN(await latestTime());
@@ -511,8 +589,9 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
             assert.equal(data[2], web3.utils.toWei("2"));
-            assert.equal(data[3].toString(), expiryTimeMA);
-            assert.equal(web3.utils.toUtf8(data[4]), "New Description");
+            assert.equal(data[3], web3.utils.toWei("2"));
+            assert.equal(data[4].toString(), expiryTimeMA);
+            assert.equal(web3.utils.toUtf8(data[5]), "New Description");
             assert.equal(tx.logs[0].args._from, account_investor1);
             assert.equal(tx.logs[0].args._to, account_investor4);
             assert.equal((tx.logs[0].args._expiryTime).toString(), expiryTimeMA);
@@ -547,8 +626,9 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
             assert.equal(data[2].toString(), web3.utils.toWei("5"));
-            assert.equal(data[3].toString(), expiryTimeMA);
-            assert.equal(web3.utils.toUtf8(data[4]), "New Description");
+            assert.equal(data[3].toString(), web3.utils.toWei("5"));
+            assert.equal(data[4].toString(), expiryTimeMA);
+            assert.equal(web3.utils.toUtf8(data[5]), "New Description");
         });
 
         it("Should transact according to new allowance", async() => {
@@ -577,13 +657,15 @@ contract("ManualApprovalTransferManager", accounts => {
             assert.equal(data[0], account_investor1);
             assert.equal(data[1], account_investor4);
             assert.equal(data[2].toString(), web3.utils.toWei("1"));
-            assert.equal(data[3].toString(), expiryTimeMA);
-            assert.equal(web3.utils.toUtf8(data[4]), "New Description");
+            assert.equal(data[3].toString(), web3.utils.toWei("1"));
+            assert.equal(data[4].toString(), expiryTimeMA);
+            assert.equal(web3.utils.toUtf8(data[5]), "New Description");
         });
 
         it("Should fail to transfer the tokens because allowance get changed", async() => {
             await catchRevert(
-                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("2"), {from: account_investor1})
+                I_SecurityToken.transfer(account_investor4, web3.utils.toWei("2"), {from: account_investor1}),
+                "Transfer Invalid"
             );
         });
 
@@ -607,13 +689,15 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Approval has been exhausted"
             );
         });
 
         it("Should fail to revoke the manual Approval -- bad owner", async() => {
             await catchRevert(
-                I_ManualApprovalTransferManager.revokeManualApproval(account_investor1, account_investor4, {from: account_investor5})
+                I_ManualApprovalTransferManager.revokeManualApproval(account_investor1, account_investor4, {from: account_investor5}),
+                "Invalid permission"
             );
         })
 
@@ -625,12 +709,13 @@ contract("ManualApprovalTransferManager", accounts => {
 
         it("Should fail to revoke the same manual approval again", async() => {
             await catchRevert(
-                I_ManualApprovalTransferManager.revokeManualApproval(account_investor1, account_investor4, {from: token_owner})
+                I_ManualApprovalTransferManager.revokeManualApproval(account_investor1, account_investor4, {from: token_owner}),
+                "Approval not exist"
             );
         });
 
         it("Should fail to add multiple manual approvals -- failed because of bad owner", async () => {
-            await catchRevert (
+            await catchRevert(
                     I_ManualApprovalTransferManager.addManualApprovalMulti(
                     [account_investor2,account_investor3],
                     [account_investor3,account_investor4],
@@ -640,12 +725,13 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: account_investor5
                     }
-                )
+                ),
+                "Invalid permission"
             )
         });
 
         it("Should fail to add multiple manual approvals -- failed because of length mismatch", async () => {
-            await catchRevert (
+            await catchRevert(
                     I_ManualApprovalTransferManager.addManualApprovalMulti(
                     [account_investor2],
                     [account_investor3,account_investor4],
@@ -655,12 +741,13 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Input array length mismatch"
             )
         });
 
         it("Should fail to add multiple manual approvals -- failed because of length mismatch", async () => {
-            await catchRevert (
+            await catchRevert(
                     I_ManualApprovalTransferManager.addManualApprovalMulti(
                     [account_investor2,account_investor3],
                     [account_investor3,account_investor4],
@@ -670,7 +757,8 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Input array length mismatch"
             )
         });
 
@@ -685,12 +773,13 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Input array length mismatch"
             )
         });
 
         it("Should fail to add multiple manual approvals -- failed because of length mismatch", async () => {
-            await catchRevert (
+            await catchRevert(
                     I_ManualApprovalTransferManager.addManualApprovalMulti(
                     [account_investor2,account_investor3],
                     [account_investor3,account_investor4],
@@ -700,11 +789,12 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "Input array length mismatch"
             )
         });
 
-        it("Add multiple manual approvals", async () => {
+        it("Add multiple manual approvals, and then retrieve", async () => {
             let time = currentTime.add(new BN(duration.days(1)));
             await I_ManualApprovalTransferManager.addManualApprovalMulti(
                 [account_investor2,account_investor3],
@@ -724,7 +814,97 @@ contract("ManualApprovalTransferManager", accounts => {
             let approvalDetail = await I_ManualApprovalTransferManager.getApprovalDetails.call(account_investor2, account_investor3);
             assert.equal(approvalDetail[0].toString(), time);
             assert.equal(approvalDetail[1].toString(), web3.utils.toWei("2", "ether"));
-            assert.equal(web3.utils.toUtf8(approvalDetail[2]), "DESCRIPTION_1");
+            assert.equal(approvalDetail[2].toString(), web3.utils.toWei("2", "ether"));
+            assert.equal(web3.utils.toUtf8(approvalDetail[3]), "DESCRIPTION_1");
+        });
+
+        it("Retrieving details of non-existent approval", async () => {
+            const approvalDetail = await I_ManualApprovalTransferManager.getApprovalDetails.call(account_investor6, account_investor7);
+            console.log('approvalDetail', approvalDetail);
+            const parsedDetail = {
+                0: approvalDetail[0].toString(),
+                1: approvalDetail[1].toString(),
+                2: approvalDetail[2].toString(),
+                3: web3.utils.hexToUtf8(approvalDetail[3])
+            }
+            assert.deepEqual({0:'0', 1:'0', 2:'0', 3: ''}, parsedDetail, "Approval doesn't exist");
+        });
+
+        it("Should fail to modify multiple approvals because of mismatched array params", async () => {
+            await catchRevert(
+                    I_ManualApprovalTransferManager.modifyManualApprovalMulti(
+                    [account_investor2],
+                    [account_investor3,account_investor4],
+                    [web3.utils.toWei("2", "ether"), web3.utils.toWei("2", "ether")],
+                    [currentTime.add(new BN(duration.days(1))),currentTime.add(new BN(duration.days(1)))],
+                    [web3.utils.fromAscii("DESCRIPTION_1"), web3.utils.fromAscii("DESCRIPTION_2")],
+                    [true, true],
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Input array length mismatch"
+            )
+
+            await catchRevert(
+                    I_ManualApprovalTransferManager.modifyManualApprovalMulti(
+                    [account_investor2,account_investor3],
+                    [account_investor3,account_investor4],
+                    [web3.utils.toWei("2", "ether"), web3.utils.toWei("2", "ether")],
+                    [currentTime.add(new BN(duration.days(1)))],
+                    [web3.utils.fromAscii("DESCRIPTION_1"), web3.utils.fromAscii("DESCRIPTION_2")],
+                    [true, true],
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Input array length mismatch"
+            )
+
+            await catchRevert(
+                    I_ManualApprovalTransferManager.modifyManualApprovalMulti(
+                    [account_investor2,account_investor3],
+                    [account_investor3,account_investor4],
+                    [web3.utils.toWei("2", "ether")],
+                    [currentTime.add(new BN(duration.days(1))),currentTime.add(new BN(duration.days(1)))],
+                    [web3.utils.fromAscii("DESCRIPTION_1"), web3.utils.fromAscii("DESCRIPTION_2")],
+                    [true, true],
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Input array length mismatch"
+            )
+
+            await catchRevert(
+                    I_ManualApprovalTransferManager.modifyManualApprovalMulti(
+                    [account_investor2,account_investor3],
+                    [account_investor3,account_investor4],
+                    [web3.utils.toWei("2", "ether"), web3.utils.toWei("2", "ether")],
+                    [currentTime.add(new BN(duration.days(1))),currentTime.add(new BN(duration.days(1)))],
+                    [web3.utils.fromAscii("DESCRIPTION_1")],
+                    [true, true],
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Input array length mismatch"
+            )
+
+            await catchRevert(
+                    I_ManualApprovalTransferManager.modifyManualApprovalMulti(
+                    [account_investor2,account_investor3],
+                    [account_investor3,account_investor4],
+                    [web3.utils.toWei("2", "ether"), web3.utils.toWei("2", "ether")],
+                    [currentTime.add(new BN(duration.days(1))),currentTime.add(new BN(duration.days(1)))],
+                    [web3.utils.fromAscii("DESCRIPTION_1"), web3.utils.fromAscii("DESCRIPTION_2")],
+                    [true],
+                    {
+                        from: token_owner
+                    }
+                ),
+                "Input array length mismatch"
+            )
         });
 
         it("Should fail to revoke the multiple manual approvals -- because of bad owner", async() => {
@@ -735,7 +915,8 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: account_investor5
                     }
-                )
+                ),
+                "Invalid permission"
             );
         })
 
@@ -747,7 +928,8 @@ contract("ManualApprovalTransferManager", accounts => {
                     {
                         from: token_owner
                     }
-                )
+                ),
+                "array length mismatch"
             );
         })
 


### PR DESCRIPTION
- `ManualApproval` struct now contains:
  - `allowance`, which is the original supplied (or modified) allowance.
  - `remainingAllowance` which keeps track of ongoing allowance.
- Added a few tests to MATM to ensure > 95% coverage.